### PR TITLE
Enhance Popup Translation UI with Loading State, Input, and Help View Refresh #86exfjner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 static/key-file.json
 *.zip
 .npmrc
+/.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Load `dist/` as an unpacked extension at `chrome://extensions`. There is no sepa
 | `main.js` | [src/main.ts](src/main.ts) | YouTube `/watch`, Netflix | Subtitle phrase collector — wraps caption words in `<Word>` spans, hover/anchor selection. |
 | `nibble.js` | [src/nibble.ts](src/nibble.ts) | `<all_urls>` | Web text phrase collector — native `Selection` → floating Subturtle icon → translation card. **Does not mutate page DOM.** |
 | `console-crane.js` | [src/console-crane.ts](src/console-crane.ts) | `<all_urls>` | The modal app (word-detail, settings, save flow). Owns its own Vue app + Pinia store + router. Feature bundles drive it via the [bridge](src/common/services/console-crane-bridge.ts). |
-| `popup.js` | [src/popup.ts](src/popup.ts) | Toolbar popup | Settings, language, dashboard link, per-site Nibble toggle. |
+| `popup.js` | [src/popup.ts](src/popup.ts) | Toolbar popup | Ad-hoc text translation (input + detailed result), settings, language, dashboard link, per-site Nibble toggle. Reuses console-crane's `WordDetailModule` for the result panel — see [Shared APIs § WordDetailModule](#worddetailmodule-detailed-translation-panel) for the cross-bundle reuse rules. |
 | `background.js` | [src/background.ts](src/background.ts) | Service worker | OAuth, token storage, settings persistence to `chrome.storage.local`, broadcast `SYNC_SETTINGS` to tabs. |
 
 Manifest content_scripts split is in [static/manifest.json](static/manifest.json). On a YouTube `/watch` page all three content scripts run side-by-side in the same isolated world — `main.js`, `nibble.js`, and `console-crane.js` — so they coordinate through shared `chrome.storage` (settings) and `window` CustomEvents (the ConsoleCrane bridge).
@@ -77,7 +77,9 @@ The console-crane content script listens (`onOpen` in [src/console-crane.ts](src
 
 **Inside the console-crane bundle itself**, code can keep using `useConsoleCraneStore()` directly — it's the same Vue app. Bridge events are only the cross-bundle path.
 
-Params are encoded into the route via `encodeRouteParams` in [src/console-crane/stores/console-crane.ts](src/console-crane/stores/console-crane.ts) — Unicode-safe (uses TextEncoder). Decode with `decodeRouteParams`. **Never use `window.btoa(JSON.stringify(...))` directly** — it throws `InvalidCharacterError` on non-Latin1 input (Persian, CJK, emoji, accented Latin).
+Params are encoded into the route via `encodeRouteParams` from [src/console-crane/route-params.ts](src/console-crane/route-params.ts) — Unicode-safe (uses TextEncoder). Decode with `decodeRouteParams`. **Never use `window.btoa(JSON.stringify(...))` directly** — it throws `InvalidCharacterError` on non-Latin1 input (Persian, CJK, emoji, accented Latin).
+
+These helpers live in their own module (separate from the store) so consumers can import them without dragging in the console-crane router. Importing them from the store would close a circular ESM init when the importer isn't `console-crane.ts` itself (popup → WordDetailModule → store → router → WordDetailModule). Keep them in `route-params.ts`.
 
 ### Translation
 
@@ -87,6 +89,25 @@ const text = await TranslateService.instance.fetchSimpleTranslation(phrase, cont
 ```
 
 24-hour in-memory cache keyed on `(translationType, targetLanguage, phrase, context)`. `fetchDetailedTranslation` for the rich `LanguageLearningData` shape used by ConsoleCrane.
+
+### WordDetailModule (detailed translation panel)
+
+[src/console-crane/modules/word-detail/index.vue](src/console-crane/modules/word-detail/index.vue) is the rich result panel — definition, phonetic, examples, related expressions, plus the bundle save UI from [SaveWordSectionV2](src/console-crane/components/SaveWordSectionV2.vue). It runs its own `fetchDetailedTranslation` call internally, so the caller just supplies inputs.
+
+It supports two mounting modes:
+
+- **Route-driven** (console-crane): mounted by the console-crane router; reads `{ word, context }` from the base64-encoded `:data` route param. This is what `emitOpen({ page: "word-detail", params })` ultimately drives.
+- **Prop-driven** (popup, anywhere outside the console-crane router): pass `:word` and optional `:context` directly. When `word` is present it's preferred over the route param.
+
+Also emits `loading: boolean` mirroring its internal pending state — bind it on the parent (e.g. the popup's [TranslateCard](src/popup/components/TranslateCard.vue)) to reflect a button spinner.
+
+**Cross-bundle reuse caveat.** The "feature bundles never import the ConsoleCrane component or its store" rule is about the modal wrapper and `useConsoleCraneStore` — they're for opening the modal on a page that already has the ConsoleCrane content script. Reusing presentational sub-modules like `WordDetailModule` (and the things it transitively pulls in: `SaveWordSectionV2`, `SelectPhraseBundleV2`, `FreemiumLimitCounter`) **is fine** as long as:
+
+1. You're in a bundle that does NOT also load `console-crane.js` (today: only the popup qualifies — it's its own Chrome extension page, not a content script).
+2. You drive the module via props, not by trying to inject route params it doesn't have.
+3. The host app installs Pinia + the modular-rest auth plugin before mount (`addPlugins(app)` from [src/plugins/install.ts](src/plugins/install.ts)).
+
+If you ever need this from a content-script bundle that runs alongside ConsoleCrane, use the [bridge](#consolecrane-bridge) instead — don't double-mount the same component on the same page.
 
 ### Settings store
 
@@ -207,7 +228,8 @@ When changes touch the bundle layout, content scripts, or shared CSS:
 - On YouTube `/watch`: subtitle popup works; Nibble selection popup also works (all three content scripts run there). Exactly one `#subturtle-console-crane-root` in the DOM.
 - On Wikipedia: only `nibble.js` and `console-crane.js` run; selection → icon → translation card → save flow opens ConsoleCrane.
 - In the popup: per-site toggle reads/writes `nibbleDisabledDomains` and survives a popup re-open. Toggling Nibble OFF for a host **while ConsoleCrane is open** must NOT close the modal or lock page scroll — the modal lifecycle is decoupled from the Nibble per-host gate via the bridge.
-- In ConsoleCrane on a non-Latin page (e.g. Persian / Chinese article): no `InvalidCharacterError` from `btoa`.
+- In the popup translate input: input is auto-focused on open; submitting renders the detailed result inline; logged-out users see "Login to save this phrase"; logged-in users get the bundle picker. Re-translating a different word resets the result. The button shows a spinner while pending.
+- In ConsoleCrane on a non-Latin page (e.g. Persian / Chinese article): no `InvalidCharacterError` from `btoa`. Same check applies to the popup translate input — paste a Persian / CJK phrase and confirm no encoding error.
 - Visual scale is consistent on a default-html-font-size site (YouTube) and a large-html-font-size site (typical WordPress blog).
 
 ## Useful pointers
@@ -219,6 +241,9 @@ When changes touch the bundle layout, content scripts, or shared CSS:
 - Background message types: [src/common/types/messaging.ts](src/common/types/messaging.ts)
 - ConsoleCrane store: [src/console-crane/stores/console-crane.ts](src/console-crane/stores/console-crane.ts)
 - ConsoleCrane bridge: [src/common/services/console-crane-bridge.ts](src/common/services/console-crane-bridge.ts)
+- Route-param helpers (Unicode-safe base64): [src/console-crane/route-params.ts](src/console-crane/route-params.ts)
+- WordDetailModule (detailed result panel, prop- or route-driven): [src/console-crane/modules/word-detail/index.vue](src/console-crane/modules/word-detail/index.vue)
+- Popup translate card: [src/popup/components/TranslateCard.vue](src/popup/components/TranslateCard.vue)
 - Settings store: [src/common/store/settings.ts](src/common/store/settings.ts)
 - Marker store: [src/stores/marker.ts](src/stores/marker.ts)
 - Translate service: [src/common/services/translate.service.ts](src/common/services/translate.service.ts)

--- a/src/console-crane/modules/word-detail/index.vue
+++ b/src/console-crane/modules/word-detail/index.vue
@@ -192,7 +192,12 @@ import { useRoute } from "vue-router";
 import { sendMessage } from "../../../common/helper/massage";
 import { OpenLoginWindowMessage } from "../../../common/types/messaging";
 import { analytic } from "../../../plugins/mixpanel";
-import { decodeRouteParams } from "../../stores/console-crane";
+import { decodeRouteParams } from "../../route-params";
+
+const props = defineProps<{
+  word?: string;
+  context?: string;
+}>();
 
 const route = useRoute();
 
@@ -201,10 +206,15 @@ onMounted(() => {
 });
 
 /**
- * Extracts word data from the route parameter
- * The data is base64 encoded in the URL
+ * Resolve word + context inputs. Prefers explicit props (used by the popup
+ * bundle, which mounts this module without a route param). Falls back to
+ * the base64-encoded `:data` route param used by the console-crane router.
  */
 function getProps() {
+  if (props.word) {
+    return { word: props.word, context: props.context ?? "" };
+  }
+
   const data = decodeRouteParams<{ word: string; context?: string }>(
     route.params.data as string
   );

--- a/src/console-crane/modules/word-detail/index.vue
+++ b/src/console-crane/modules/word-detail/index.vue
@@ -199,6 +199,10 @@ const props = defineProps<{
   context?: string;
 }>();
 
+const emit = defineEmits<{
+  loading: [boolean];
+}>();
+
 const route = useRoute();
 
 onMounted(() => {
@@ -231,6 +235,9 @@ const wordData = ref<LanguageLearningData | null>(null); // Stores detailed ling
 const pending = ref(false); // Loading state
 const error = ref<string | null>(null); // Translation error message, null when ok
 const key = ref(new Date().getTime()); // Key for forcing component refresh
+
+// Mirror loading state to parent so popup callers can show a button spinner.
+watch(pending, (val) => emit("loading", val));
 
 // Gets the title of the target language (e.g., "Spanish", "French")
 const targetLanguageTitle = computed(

--- a/src/console-crane/route-params.ts
+++ b/src/console-crane/route-params.ts
@@ -1,0 +1,21 @@
+// Unicode-safe base64 helpers for vue-router params. Lives in its own module
+// (no router/store imports) so consumers like the popup's WordDetailModule
+// can pull only what they need without dragging in the console-crane router
+// — that import path causes a circular ESM init in non-console-crane bundles.
+//
+// `btoa` only accepts Latin1 — any non-Latin1 character (e.g. accented Latin,
+// Persian, Chinese, emoji) throws InvalidCharacterError. We encode via
+// TextEncoder so route params can carry any text.
+export function encodeRouteParams(params: any): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(params));
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
+export function decodeRouteParams<T = any>(data: string): T {
+  const binary = atob(data);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return JSON.parse(new TextDecoder().decode(bytes));
+}

--- a/src/console-crane/stores/console-crane.ts
+++ b/src/console-crane/stores/console-crane.ts
@@ -3,27 +3,11 @@ import { ref, computed } from "vue";
 import { ConsolePage } from "../types";
 
 import { router } from "../router";
+import { encodeRouteParams } from "../route-params";
 
 interface PageEntry {
   name: ConsolePage;
   params?: Record<string, any>;
-}
-
-// Unicode-safe base64. `btoa` only accepts Latin1 — any non-Latin1 character
-// (e.g. accented Latin, Persian, Chinese, emoji) throws InvalidCharacterError.
-// We encode via TextEncoder so route params can carry any text.
-export function encodeRouteParams(params: any): string {
-  const bytes = new TextEncoder().encode(JSON.stringify(params));
-  let binary = "";
-  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
-  return btoa(binary);
-}
-
-export function decodeRouteParams<T = any>(data: string): T {
-  const binary = atob(data);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return JSON.parse(new TextDecoder().decode(bytes));
 }
 
 export const useConsoleCraneStore = defineStore("console-crane", () => {

--- a/src/popup/components/TranslateCard.vue
+++ b/src/popup/components/TranslateCard.vue
@@ -1,0 +1,60 @@
+<template>
+  <section class="space-y-4">
+    <div
+      class="bg-gray-50 dark:bg-white/[0.03] backdrop-blur-xl rounded-xl p-4 border border-gray-200 dark:border-white/[0.08] shadow-xl hover:border-gray-300 dark:hover:border-white/[0.12] transition-all duration-300"
+    >
+      <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-1">
+        Translate any text
+      </h3>
+      <p class="text-gray-600 dark:text-gray-400 text-sm mb-3">
+        Type or paste any phrase to see its detailed translation. Save it to your
+        bundles when logged in.
+      </p>
+
+      <form class="flex gap-2" @submit.prevent="submit">
+        <input
+          ref="inputEl"
+          v-model="inputText"
+          type="text"
+          :placeholder="placeholder"
+          autocomplete="off"
+          spellcheck="false"
+          class="flex-1 px-3 py-2 rounded-md bg-white dark:bg-white/[0.04] border border-gray-200 dark:border-white/[0.08] text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-400/40 focus:border-purple-400/40"
+        />
+        <button
+          type="submit"
+          :disabled="!inputText.trim()"
+          class="px-5 py-2 rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 hover:from-indigo-600 hover:via-purple-600 hover:to-pink-600 text-white text-sm font-medium shadow-lg hover:shadow-purple-500/25 transition-all transform hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:shadow-none whitespace-nowrap"
+        >
+          Translate
+        </button>
+      </form>
+    </div>
+
+    <div v-if="submittedWord" class="rounded-xl overflow-hidden">
+      <WordDetailModule :word="submittedWord" />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, nextTick } from "vue";
+import WordDetailModule from "../../console-crane/modules/word-detail/index.vue";
+
+const placeholder = "Type or paste any text to translate…";
+
+const inputEl = ref<HTMLInputElement | null>(null);
+const inputText = ref("");
+const submittedWord = ref("");
+
+onMounted(async () => {
+  await nextTick();
+  inputEl.value?.focus();
+});
+
+function submit() {
+  const text = inputText.value.trim();
+  if (!text) return;
+  submittedWord.value = text;
+}
+</script>

--- a/src/popup/components/TranslateCard.vue
+++ b/src/popup/components/TranslateCard.vue
@@ -23,16 +23,37 @@
         />
         <button
           type="submit"
-          :disabled="!inputText.trim()"
-          class="px-5 py-2 rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 hover:from-indigo-600 hover:via-purple-600 hover:to-pink-600 text-white text-sm font-medium shadow-lg hover:shadow-purple-500/25 transition-all transform hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:shadow-none whitespace-nowrap"
+          :disabled="!inputText.trim() || loading"
+          class="px-5 py-2 rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 hover:from-indigo-600 hover:via-purple-600 hover:to-pink-600 text-white text-sm font-medium shadow-lg hover:shadow-purple-500/25 transition-all transform hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:shadow-none whitespace-nowrap inline-flex items-center justify-center gap-2 min-w-[7rem]"
         >
-          Translate
+          <svg
+            v-if="loading"
+            class="animate-spin h-4 w-4 text-white"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              class="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+            />
+            <path
+              class="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+          {{ loading ? "Translating…" : "Translate" }}
         </button>
       </form>
     </div>
 
     <div v-if="submittedWord" class="rounded-xl overflow-hidden">
-      <WordDetailModule :word="submittedWord" />
+      <WordDetailModule :word="submittedWord" @loading="loading = $event" />
     </div>
   </section>
 </template>
@@ -46,6 +67,7 @@ const placeholder = "Type or paste any text to translate…";
 const inputEl = ref<HTMLInputElement | null>(null);
 const inputText = ref("");
 const submittedWord = ref("");
+const loading = ref(false);
 
 onMounted(async () => {
   await nextTick();
@@ -54,7 +76,12 @@ onMounted(async () => {
 
 function submit() {
   const text = inputText.value.trim();
-  if (!text) return;
+  // Skip if empty or unchanged — re-submitting the same word wouldn't trigger
+  // WordDetailModule's prop watcher, so the loading flag would never clear.
+  if (!text || text === submittedWord.value) return;
+  // Set immediately for snappy feedback; WordDetailModule's emit will
+  // turn it off when the fetch settles (or hand it back to true on retry).
+  loading.value = true;
   submittedWord.value = text;
 }
 </script>

--- a/src/popup/router.ts
+++ b/src/popup/router.ts
@@ -37,22 +37,19 @@ export const router = createRouter({
   routes: routes,
 });
 
-router.beforeEach(async (to, from) => {
-  // Allow access to intro and login pages regardless of login status
+router.beforeEach(async (to) => {
+  // Intro and login pages bypass the silent re-auth attempt entirely.
   if (to.name === "intro" || to.name === "login") {
     return true;
   }
 
-  // Try to login with last session if not already logged in
+  // Best-effort silent re-auth so logged-in users hit a populated state on
+  // first paint. We deliberately do NOT redirect on failure — the home view
+  // (and the new translation card on it) is reachable for logged-out users;
+  // auth-gated UI inside HomeView is hidden via `v-if="isLogin"`.
   if (!isLogin.value) {
     await loginWithLastSession();
-
-    // After trying to login, check again if successful
-    if (!isLogin.value) {
-      return { name: "intro" };
-    }
   }
 
-  // If we got here, user is logged in, allow navigation
   return true;
 });

--- a/src/popup/views/HelpView.vue
+++ b/src/popup/views/HelpView.vue
@@ -35,284 +35,410 @@
       <!-- Subtitle -->
       <div class="text-center py-4 mb-2">
         <p class="text-gray-600 dark:text-gray-400">
-          Follow these simple steps to enhance your learning experience
+          Three ways to capture words, one place to learn them.
         </p>
       </div>
 
-      <!-- Steps Timeline Layout -->
       <div class="px-8 py-4">
-        <div class="relative">
-          <!-- Timeline Line -->
+        <!-- Capture section -->
+        <div class="mb-8">
           <div
-            class="absolute left-8 top-0 bottom-0 w-[2px] bg-gradient-to-b from-blue-500/50 via-purple-500/50 to-emerald-500/50"
-          ></div>
+            class="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-4 px-2"
+          >
+            Capture
+          </div>
 
-          <!-- Step 1 -->
-          <div class="relative flex mb-12">
-            <div class="shrink-0 w-16 flex items-start justify-center">
-              <div class="relative">
-                <div
-                  class="w-8 h-8 rounded-full bg-gradient-to-br from-blue-400 to-blue-600 flex items-center justify-center shadow-lg shadow-blue-500/20"
-                >
-                  <span class="text-lg font-semibold text-white">1</span>
-                </div>
-              </div>
-            </div>
+          <div class="grid grid-cols-3 gap-4">
+            <!-- Video subtitles -->
             <div
-              class="flex-1 bg-gradient-to-br from-blue-500/5 to-blue-600/10 backdrop-blur-lg rounded-xl p-6 border border-blue-400/20 transform transition-all hover:scale-[1.02] hover:border-blue-400/40 hover:from-blue-500/10 hover:to-blue-600/20"
+              class="flex flex-col p-5 rounded-xl backdrop-blur-lg bg-gradient-to-br from-blue-500/5 to-blue-600/10 border border-blue-400/20 hover:scale-[1.02] hover:border-blue-400/40 hover:from-blue-500/10 hover:to-blue-600/20 transition-all"
             >
-              <h3 class="text-xl font-semibold text-blue-400 mb-3">
-                Open Video & Enable Subtitles
+              <div
+                class="w-10 h-10 rounded-full bg-gradient-to-br from-blue-400 to-blue-600 flex items-center justify-center shadow-lg shadow-blue-500/20"
+              >
+                <svg
+                  class="w-5 h-5 text-white"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+              <h3 class="text-lg font-semibold text-blue-400 mt-3 mb-2">
+                Video subtitles
               </h3>
-              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                Open a video on Netflix or YouTube, enable subtitles, and hover
-                over words to see instant translations. It's that simple to get
-                started!
+              <p
+                class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed mb-3"
+              >
+                Open Netflix or YouTube, turn on subtitles, and hover any word
+                for an instant translation.
               </p>
+              <div
+                class="text-xs text-gray-600 dark:text-gray-400 mt-auto pt-2 border-t border-blue-400/10"
+              >
+                Click the
+                <kbd
+                  class="px-1.5 py-0.5 bg-gray-200 dark:bg-white/10 rounded text-xs"
+                  >+</kbd
+                >
+                anchors on either side of a word to extend the selection one
+                word at a time.
+              </div>
             </div>
-          </div>
 
-          <!-- Step 2 -->
-          <div class="relative flex mb-12">
-            <div class="shrink-0 w-16 flex items-start justify-center">
-              <div class="relative">
-                <div
-                  class="w-8 h-8 rounded-full bg-gradient-to-br from-purple-400 to-purple-600 flex items-center justify-center shadow-lg shadow-purple-500/20"
-                >
-                  <span class="text-lg font-semibold text-white">2</span>
-                </div>
-              </div>
-            </div>
+            <!-- Any webpage (Nibble) -->
             <div
-              class="flex-1 bg-gradient-to-br from-purple-500/5 to-purple-600/10 backdrop-blur-lg rounded-xl p-6 border border-purple-400/20 transform transition-all hover:scale-[1.02] hover:border-purple-400/40 hover:from-purple-500/10 hover:to-purple-600/20"
+              class="flex flex-col p-5 rounded-xl backdrop-blur-lg bg-gradient-to-br from-purple-500/5 to-purple-600/10 border border-purple-400/20 hover:scale-[1.02] hover:border-purple-400/40 hover:from-purple-500/10 hover:to-purple-600/20 transition-all"
             >
-              <h3 class="text-xl font-semibold text-purple-400 mb-3">
-                Select Multiple Words
+              <div
+                class="w-10 h-10 rounded-full bg-gradient-to-br from-purple-400 to-purple-600 flex items-center justify-center shadow-lg shadow-purple-500/20"
+              >
+                <svg
+                  class="w-5 h-5 text-white"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5"
+                  />
+                </svg>
+              </div>
+              <h3 class="text-lg font-semibold text-purple-400 mt-3 mb-2">
+                Any webpage
               </h3>
-              <div class="space-y-3">
-                <div
-                  class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
-                >
-                  <span
-                    class="flex-shrink-0 w-6 h-6 rounded-full bg-purple-500/20 flex items-center justify-center"
-                    >1</span
-                  >
-                  <span
-                    >Hold
-                    <kbd
-                      class="px-2 py-1 bg-gray-200 dark:bg-white/10 rounded text-sm"
-                      >Ctrl</kbd
-                    >
-                    or
-                    <kbd
-                      class="px-2 py-1 bg-gray-200 dark:bg-white/10 rounded text-sm"
-                      >⌘ Command</kbd
-                    ></span
-                  >
-                </div>
-                <div
-                  class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
-                >
-                  <span
-                    class="flex-shrink-0 w-6 h-6 rounded-full bg-purple-500/20 flex items-center justify-center"
-                    >2</span
-                  >
-                  <span>Drag to select multiple words for translation</span>
-                </div>
-                <div
-                  class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
-                >
-                  <span
-                    class="flex-shrink-0 w-6 h-6 rounded-full bg-purple-500/20 flex items-center justify-center"
-                    >3</span
-                  >
-                  <span>Click to save selected words for later practice</span>
-                </div>
+              <p
+                class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed mb-3"
+              >
+                Highlight text on any site — Wikipedia, articles, blogs. A
+                floating Subturtle icon appears for an instant translation.
+              </p>
+              <div
+                class="text-xs text-gray-600 dark:text-gray-400 mt-auto pt-2 border-t border-purple-400/10"
+              >
+                Click the icon, then hit
+                <span class="text-purple-400 font-medium">Save & view</span>
+                to open the full word details.
               </div>
             </div>
-          </div>
 
-          <!-- Step 3 -->
-          <div class="relative flex mb-12">
-            <div class="shrink-0 w-16 flex items-start justify-center">
-              <div class="relative">
-                <div
-                  class="w-8 h-8 rounded-full bg-gradient-to-br from-amber-400 to-amber-600 flex items-center justify-center shadow-lg shadow-amber-500/20"
-                >
-                  <span class="text-lg font-semibold text-white">3</span>
-                </div>
-              </div>
-            </div>
+            <!-- Quick translate (Popup) -->
             <div
-              class="flex-1 bg-gradient-to-br from-amber-500/5 to-amber-600/10 backdrop-blur-lg rounded-xl p-6 border border-amber-400/20 transform transition-all hover:scale-[1.02] hover:border-amber-400/40 hover:from-amber-500/10 hover:to-amber-600/20"
+              class="flex flex-col p-5 rounded-xl backdrop-blur-lg bg-gradient-to-br from-amber-500/5 to-amber-600/10 border border-amber-400/20 hover:scale-[1.02] hover:border-amber-400/40 hover:from-amber-500/10 hover:to-amber-600/20 transition-all"
             >
-              <h3 class="text-xl font-semibold text-amber-400 mb-3">
-                Save & Organize
+              <div
+                class="w-10 h-10 rounded-full bg-gradient-to-br from-amber-400 to-amber-600 flex items-center justify-center shadow-lg shadow-amber-500/20"
+              >
+                <svg
+                  class="w-5 h-5 text-white"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"
+                  />
+                </svg>
+              </div>
+              <h3 class="text-lg font-semibold text-amber-400 mt-3 mb-2">
+                Quick translate
               </h3>
-              <div class="space-y-3">
-                <div
-                  class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
-                >
-                  <svg
-                    class="w-5 h-5 text-amber-400"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 5l7 7-7 7"
-                    />
-                  </svg>
-                  <span>View detailed translations and examples</span>
-                </div>
-                <div
-                  class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
-                >
-                  <svg
-                    class="w-5 h-5 text-amber-400"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 5l7 7-7 7"
-                    />
-                  </svg>
-                  <span>Save important phrases to your collection</span>
-                </div>
-                <div
-                  class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
-                >
-                  <svg
-                    class="w-5 h-5 text-amber-400"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 5l7 7-7 7"
-                    />
-                  </svg>
-                  <span>Create custom bundles for organized learning</span>
-                </div>
+              <p
+                class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed mb-3"
+              >
+                Open this popup and type or paste any phrase. Get a translation
+                instantly, no page visit needed.
+              </p>
+              <div
+                class="text-xs text-gray-600 dark:text-gray-400 mt-auto pt-2 border-t border-amber-400/10"
+              >
+                Perfect for quick lookups while you're reading anywhere — even
+                a paper book.
               </div>
             </div>
           </div>
+        </div>
 
-          <!-- Step 4 -->
-          <div class="relative flex">
-            <div class="shrink-0 w-16 flex items-start justify-center">
-              <div class="relative">
-                <div
-                  class="w-8 h-8 rounded-full bg-gradient-to-br from-emerald-400 to-emerald-600 flex items-center justify-center shadow-lg shadow-emerald-500/20"
-                >
-                  <span class="text-lg font-semibold text-white">4</span>
-                </div>
-              </div>
-            </div>
+        <!-- Learn section -->
+        <div class="mb-8">
+          <div
+            class="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-4 px-2"
+          >
+            Learn
+          </div>
+
+          <div class="relative">
+            <!-- Timeline Line -->
             <div
-              class="flex-1 bg-gradient-to-br from-emerald-500/5 to-emerald-600/10 backdrop-blur-lg rounded-xl p-6 border border-emerald-400/20 transform transition-all hover:scale-[1.02] hover:border-emerald-400/40 hover:from-emerald-500/10 hover:to-emerald-600/20"
-            >
-              <h3 class="text-xl font-semibold text-emerald-400 mb-4">
-                Practice & Master
-              </h3>
-              <div class="grid grid-cols-2 gap-6">
-                <div class="space-y-3">
-                  <h4 class="text-lg font-medium text-emerald-400">
-                    Practice Modes
-                  </h4>
-                  <div class="space-y-2">
-                    <div
-                      class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
-                    >
-                      <svg
-                        class="w-5 h-5 text-emerald-400"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M5 13l4 4L19 7"
-                        />
-                      </svg>
-                      <span>Interactive flashcards</span>
-                    </div>
-                    <div
-                      class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
-                    >
-                      <svg
-                        class="w-5 h-5 text-emerald-400"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M5 13l4 4L19 7"
-                        />
-                      </svg>
-                      <span>AI-powered practice sessions</span>
-                    </div>
-                  </div>
-                </div>
-                <div class="space-y-3">
-                  <h4 class="text-lg font-medium text-emerald-400">
-                    Track Progress
-                  </h4>
-                  <div class="space-y-2">
-                    <div
-                      class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
-                    >
-                      <svg
-                        class="w-5 h-5 text-emerald-400"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M5 13l4 4L19 7"
-                        />
-                      </svg>
-                      <span>Organize word bundles</span>
-                    </div>
-                    <div
-                      class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
-                    >
-                      <svg
-                        class="w-5 h-5 text-emerald-400"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M5 13l4 4L19 7"
-                        />
-                      </svg>
-                      <span>Monitor learning progress</span>
-                    </div>
+              class="absolute left-8 top-0 bottom-0 w-[2px] bg-gradient-to-b from-emerald-500/50 to-rose-500/50"
+            ></div>
+
+            <!-- Step 1: Save & Organize -->
+            <div class="relative flex mb-8">
+              <div class="shrink-0 w-16 flex items-start justify-center">
+                <div class="relative">
+                  <div
+                    class="w-8 h-8 rounded-full bg-gradient-to-br from-emerald-400 to-emerald-600 flex items-center justify-center shadow-lg shadow-emerald-500/20"
+                  >
+                    <span class="text-lg font-semibold text-white">1</span>
                   </div>
                 </div>
               </div>
+              <div
+                class="flex-1 bg-gradient-to-br from-emerald-500/5 to-emerald-600/10 backdrop-blur-lg rounded-xl p-6 border border-emerald-400/20 transform transition-all hover:scale-[1.02] hover:border-emerald-400/40 hover:from-emerald-500/10 hover:to-emerald-600/20"
+              >
+                <h3 class="text-xl font-semibold text-emerald-400 mb-3">
+                  Save & Organize
+                </h3>
+                <div class="space-y-3">
+                  <div
+                    class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
+                  >
+                    <svg
+                      class="w-5 h-5 text-emerald-400"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                    <span>View detailed translations and examples</span>
+                  </div>
+                  <div
+                    class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
+                  >
+                    <svg
+                      class="w-5 h-5 text-emerald-400"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                    <span>Save important phrases to your collection</span>
+                  </div>
+                  <div
+                    class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
+                  >
+                    <svg
+                      class="w-5 h-5 text-emerald-400"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                    <span>Group phrases into custom bundles</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Step 2: Practice & Master -->
+            <div class="relative flex">
+              <div class="shrink-0 w-16 flex items-start justify-center">
+                <div class="relative">
+                  <div
+                    class="w-8 h-8 rounded-full bg-gradient-to-br from-rose-400 to-rose-600 flex items-center justify-center shadow-lg shadow-rose-500/20"
+                  >
+                    <span class="text-lg font-semibold text-white">2</span>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="flex-1 bg-gradient-to-br from-rose-500/5 to-rose-600/10 backdrop-blur-lg rounded-xl p-6 border border-rose-400/20 transform transition-all hover:scale-[1.02] hover:border-rose-400/40 hover:from-rose-500/10 hover:to-rose-600/20"
+              >
+                <h3 class="text-xl font-semibold text-rose-400 mb-4">
+                  Practice & Master
+                </h3>
+                <div class="grid grid-cols-2 gap-6">
+                  <div class="space-y-3">
+                    <h4 class="text-lg font-medium text-rose-400">
+                      Practice Modes
+                    </h4>
+                    <div class="space-y-2">
+                      <div
+                        class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
+                      >
+                        <svg
+                          class="w-5 h-5 text-rose-400"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M5 13l4 4L19 7"
+                          />
+                        </svg>
+                        <span>Interactive flashcards</span>
+                      </div>
+                      <div
+                        class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
+                      >
+                        <svg
+                          class="w-5 h-5 text-rose-400"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M5 13l4 4L19 7"
+                          />
+                        </svg>
+                        <span>AI-powered practice sessions</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="space-y-3">
+                    <h4 class="text-lg font-medium text-rose-400">
+                      Track Progress
+                    </h4>
+                    <div class="space-y-2">
+                      <div
+                        class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
+                      >
+                        <svg
+                          class="w-5 h-5 text-rose-400"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M5 13l4 4L19 7"
+                          />
+                        </svg>
+                        <span>Organize word bundles</span>
+                      </div>
+                      <div
+                        class="flex items-center space-x-2 text-gray-700 dark:text-gray-300"
+                      >
+                        <svg
+                          class="w-5 h-5 text-rose-400"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M5 13l4 4L19 7"
+                          />
+                        </svg>
+                        <span>Monitor learning progress</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Popup tips footer -->
+        <div
+          class="mt-8 p-5 rounded-xl bg-gray-50 dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.08]"
+        >
+          <h3
+            class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3"
+          >
+            From this popup you can also…
+          </h3>
+          <div class="space-y-2">
+            <div
+              class="flex items-start space-x-3 text-sm text-gray-600 dark:text-gray-400"
+            >
+              <svg
+                class="w-4 h-4 text-gray-500 shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
+                />
+              </svg>
+              <span
+                >Disable Subturtle on a specific website using the per-site
+                toggle.</span
+              >
+            </div>
+            <div
+              class="flex items-start space-x-3 text-sm text-gray-600 dark:text-gray-400"
+            >
+              <svg
+                class="w-4 h-4 text-gray-500 shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <span>Change the language you're learning from videos.</span>
+            </div>
+            <div
+              class="flex items-start space-x-3 text-sm text-gray-600 dark:text-gray-400"
+            >
+              <svg
+                class="w-4 h-4 text-gray-500 shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                />
+              </svg>
+              <span
+                >Open the dashboard to manage saved phrases and practice.</span
+              >
             </div>
           </div>
         </div>

--- a/src/popup/views/HomeView.vue
+++ b/src/popup/views/HomeView.vue
@@ -8,6 +8,13 @@
         <!-- Translate any text -->
         <TranslateCard />
 
+        <!-- Section divider between the translation surface and the rest of
+             the popup so the result detail doesn't visually bleed into the
+             settings cards below. -->
+        <div
+          class="h-px bg-gradient-to-r from-transparent via-gray-300/70 to-transparent dark:via-white/[0.12]"
+        ></div>
+
         <!-- Control Panel -->
         <div
           class="bg-gray-50 dark:bg-white/[0.03] backdrop-blur-xl rounded-xl p-4 border border-gray-200 dark:border-white/[0.08] shadow-xl hover:border-gray-300 dark:hover:border-white/[0.12] transition-all duration-300"

--- a/src/popup/views/HomeView.vue
+++ b/src/popup/views/HomeView.vue
@@ -3,35 +3,11 @@
     <div
       class="min-h-[600px] w-full bg-gradient-to-br from-gray-50 via-white to-gray-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 overflow-y-auto"
     >
-      <!-- Hero Section -->
-      <div class="relative overflow-hidden">
-        <div
-          class="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-purple-600/20"
-        ></div>
-        <div class="relative px-6 py-4">
-          <div class="flex items-center justify-between">
-            <div class="flex-1">
-              <h1 class="text-xl font-bold text-gray-900 dark:text-white mb-1">
-                Learn English by streaming your&nbsp;
-                <span
-                  class="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-400"
-                >
-                  favorite shows
-                </span>
-              </h1>
-              <p class="text-gray-700 dark:text-gray-300 text-sm max-w-md">
-                From subtitles to fluency. Learn from real-life, native content.
-              </p>
-            </div>
-            <div class="transform hover:scale-105 transition-transform">
-              <logo></logo>
-            </div>
-          </div>
-        </div>
-      </div>
-
       <!-- Main Content -->
       <div class="p-6 space-y-6">
+        <!-- Translate any text -->
+        <TranslateCard />
+
         <!-- Control Panel -->
         <div
           class="bg-gray-50 dark:bg-white/[0.03] backdrop-blur-xl rounded-xl p-4 border border-gray-200 dark:border-white/[0.08] shadow-xl hover:border-gray-300 dark:hover:border-white/[0.12] transition-all duration-300"
@@ -286,6 +262,19 @@
               </div>
             </div>
           </div>
+
+          <router-link
+            v-else
+            to="/intro"
+            class="text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 text-sm transition-colors duration-200"
+          >
+            Want to
+            <span
+              class="text-indigo-500 dark:text-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-300 underline decoration-dotted underline-offset-4 ml-1"
+            >
+              &nbsp;Log in?
+            </span>
+          </router-link>
         </div>
       </div>
     </div>
@@ -299,6 +288,7 @@ import { isLogin, logout } from "../../plugins/modular-rest";
 import { useRouter } from "vue-router";
 import { getSubturtleDashboardUrlWithToken } from "../../common/static/global";
 import { useSettingsStore } from "../../common/store/settings";
+import TranslateCard from "../components/TranslateCard.vue";
 
 const router = useRouter();
 const isLoading = ref(false);


### PR DESCRIPTION
🏷️ PR Title: Enhance Popup Translation UI with Loading State, Input, and Help View Refresh

## 📋 Summary
This PR introduces several improvements to the popup translation feature, including adding a loading state and section divider for better UI clarity, implementing a translation input on the popup home view for direct user input, and refreshing the popup help view to cover web text and quick translate functionalities.

## 🔗 Related Tasks
[#86exfjner](https://app.clickup.com/t/86exfjner) - Implement single translate on popup page; add loading state and section divider; refresh popup help view to cover web text and quick translate; add translate input on popup home view

## 📝 Additional Details
These changes aim to enhance the user experience by providing clearer visual feedback during translation operations and expanding the help documentation within the popup to assist users better.

## 📜 Commit List
- [9c89f83](#) feat: add loading state and section divider to popup translate  
- [a0968ec](#) feat: refresh popup help view to cover web text and quick translate #86exfjner  
- [efb435c](#) feat: add translate input on popup home view  
- [adb4be4](#) Merge branch 'dev' into CU-86exfjner_Implement-single-translate-on-popup-page_Navid-Shad