### PR TITLE
feat: announce extension presence on dashboard origins for install nudge #86exkh0z3

### DIFF
--- a/src/plugins/modular-rest.ts
+++ b/src/plugins/modular-rest.ts
@@ -38,6 +38,38 @@ if (typeof Storage !== "undefined" && isDashboardOrigin()) {
   };
 }
 
+// Announce extension presence to the dashboard so it can hide the "install
+// the extension" nudge. window.postMessage crosses the content-script /
+// page-world boundary; the message is scoped to the page's own origin.
+if (typeof window !== "undefined" && isDashboardOrigin()) {
+  const announcePresence = () => {
+    try {
+      window.postMessage(
+        {
+          source: "subturtle-extension",
+          type: "presence",
+          version: chrome.runtime.getManifest().version,
+        },
+        window.location.origin
+      );
+    } catch (_e) {
+      // postMessage can fail in odd sandboxed iframes — non-fatal.
+    }
+  };
+
+  // Announce immediately in case the dashboard listener is already attached.
+  announcePresence();
+
+  // Respond to dashboard pings in case the dashboard mounts after us.
+  window.addEventListener("message", (event) => {
+    if (event.source !== window) return;
+    const data = event.data;
+    if (data?.source === "subturtle-dashboard" && data?.type === "ping") {
+      announcePresence();
+    }
+  });
+}
+
 import { GlobalOptions, authentication } from "@modular-rest/client";
 
 import { sendMessage, sendMessageToTabs } from "../common/helper/massage";


### PR DESCRIPTION
🏷️ PR Title:  
feat: announce extension presence on dashboard origins for install nudge

## 📋 Summary  
This PR introduces a feature that announces the presence of the extension on dashboard origins to trigger an install nudge. It enhances user awareness and encourages installation through contextual prompts.

## 🔗 Related Tasks  
[#86exkh0z3](https://app.clickup.com/t/86exkh0z3) - Announce extension presence on dashboard origins for install nudge

## 📝 Additional Details  
The implementation ensures that the extension correctly detects dashboard origins and signals its presence to enable the install nudge mechanism effectively.

## 📜 Commit List  
[69dcf1b](commit-url) feat: announce extension presence on dashboard origins for install nudge #86exkh0z3