### PR TITLE
practice now config page in console crane with deep link to dashboard tab #86exnxnw7

### DIFF
--- a/src/common/services/live-voices.service.ts
+++ b/src/common/services/live-voices.service.ts
@@ -1,0 +1,54 @@
+import { functionProvider } from "@modular-rest/client";
+
+/**
+ * AI-coach voice as returned by the server's `get-live-session-voices`
+ * function. Kept structurally in sync with the dashboard's `CoachVoice`
+ * (server: live_session/voices.ts) — the two repos build separately so the
+ * shape is mirrored, not imported.
+ */
+export interface CoachVoice {
+  name: string;
+  label: string;
+  description?: string;
+  gender?: "female" | "male";
+  avatarColor?: string;
+  avatarUrl?: string | null;
+}
+
+/**
+ * Cached fetch of the coach voices. Singleton so every Practice now mount
+ * shares one network call (mirrors BundleSuggestionService / TranslateService).
+ *
+ * No offline fallback: if the server can't return voices, the dashboard live
+ * session can't run anyway, so an empty list is the honest result.
+ */
+export class LiveVoicesService {
+  private static _instance: LiveVoicesService | null = null;
+
+  static get instance(): LiveVoicesService {
+    if (!this._instance) this._instance = new LiveVoicesService();
+    return this._instance;
+  }
+
+  private cache: CoachVoice[] | null = null;
+  private inflight: Promise<CoachVoice[]> | null = null;
+
+  async getVoices(): Promise<CoachVoice[]> {
+    if (this.cache) return this.cache;
+    if (this.inflight) return this.inflight;
+
+    this.inflight = functionProvider
+      .run<CoachVoice[]>({ name: "get-live-session-voices", args: {} })
+      .then((res) => {
+        this.cache = res || [];
+        return this.cache;
+      })
+      // Don't cache failures, so a transient error retries on the next open.
+      .catch(() => [] as CoachVoice[])
+      .finally(() => {
+        this.inflight = null;
+      });
+
+    return this.inflight;
+  }
+}

--- a/src/common/static/global.ts
+++ b/src/common/static/global.ts
@@ -4,10 +4,14 @@ export const VERSION = require("../../../package.json").version;
 
 export const SUBTURTLE_DASHBOARD_URL = process.env.SUBTURTLE_DASHBOARD_URL;
 
-export function getSubturtleDashboardUrlWithToken() {
+export function getSubturtleDashboardUrlWithToken(redirectPath?: string) {
   const token = authentication.getToken;
-  const url = `${process.env.SUBTURTLE_DASHBOARD_URL}/#/auth/login_with_token?token=${token}`;
-  console.log("Subturtle dashboard url", url);
+  let url = `${process.env.SUBTURTLE_DASHBOARD_URL}/#/auth/login_with_token?token=${token}`;
+  // The dashboard's login_with_token page reads `redirect`, validates same-origin,
+  // and pushes it after auth — so a deep-link survives the token handoff.
+  if (redirectPath) {
+    url += `&redirect=${encodeURIComponent(redirectPath)}`;
+  }
   return url;
 }
 

--- a/src/console-crane/components/SaveWordSectionV2.vue
+++ b/src/console-crane/components/SaveWordSectionV2.vue
@@ -70,6 +70,11 @@ const props = defineProps<{
   chunks?: Chunk[];
 }>();
 
+const emit = defineEmits<{
+  /** Fired after a successful save, carrying the created phrase document. */
+  saved: [PhraseType];
+}>();
+
 const selectBundleRef = ref();
 const selectedBundles = ref<string[]>([]);
 const existingBundles = ref<PhraseBundleType[]>([]);
@@ -351,6 +356,10 @@ async function savePhrase() {
     suggestedName.value = "";
     await loadExistingBundles();
     await profileStore.fetchSubscription();
+
+    if (existedPhrase.value) {
+      emit("saved", existedPhrase.value);
+    }
 
     if (selectBundleRef.value?.closeDropdown) {
       selectBundleRef.value.closeDropdown();

--- a/src/console-crane/components/VoicePicker.vue
+++ b/src/console-crane/components/VoicePicker.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <div v-if="loading" class="grid grid-cols-3 gap-2">
+      <div v-for="i in 6" :key="i" class="h-[88px] rounded-xl bg-gray-100 dark:bg-white/[0.06] animate-pulse" />
+    </div>
+    <div v-else class="grid grid-cols-3 gap-2">
+      <button
+        v-for="v in voices"
+        :key="v.name"
+        type="button"
+        @click="$emit('update:modelValue', v.name)"
+        :class="[
+          'flex flex-col items-center gap-1.5 rounded-xl border p-2.5 text-center transition-all focus:outline-none',
+          modelValue === v.name
+            ? 'border-purple-500 bg-purple-50 ring-2 ring-purple-500/30 dark:bg-purple-500/10'
+            : 'border-gray-200 hover:border-purple-300 dark:border-white/[0.08] dark:hover:border-purple-500/40',
+        ]"
+      >
+        <img v-if="v.avatarUrl" :src="v.avatarUrl" :alt="v.label" class="h-11 w-11 rounded-full object-cover" />
+        <span
+          v-else
+          class="flex h-11 w-11 items-center justify-center rounded-full text-base font-semibold text-white"
+          :style="{ backgroundColor: v.avatarColor || '#7C3AED' }"
+        >{{ initial(v) }}</span>
+        <span class="text-xs font-medium text-gray-900 dark:text-gray-100">{{ v.label }}</span>
+        <span v-if="v.description" class="text-[10px] leading-tight text-gray-500 dark:text-gray-400">
+          {{ v.description }}
+        </span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { LiveVoicesService, type CoachVoice } from "../../common/services/live-voices.service";
+
+defineProps<{ modelValue: string }>();
+defineEmits<{ "update:modelValue": [value: string] }>();
+
+const voices = ref<CoachVoice[]>([]);
+const loading = ref(true);
+
+onMounted(async () => {
+  try {
+    voices.value = await LiveVoicesService.instance.getVoices();
+  } finally {
+    loading.value = false;
+  }
+});
+
+function initial(v: CoachVoice): string {
+  return (v.label || v.name).charAt(0).toUpperCase();
+}
+</script>

--- a/src/console-crane/modules/practice-config/deep-link.ts
+++ b/src/console-crane/modules/practice-config/deep-link.ts
@@ -1,0 +1,50 @@
+/**
+ * "Practice now" -> dashboard deep-link.
+ *
+ * Practice now is a single-phrase voice session. It hands the saved phrase to
+ * the dashboard's single live-session gate (`/practice/live-session`) as a
+ * base64-encoded LiveSessionRequest with a `phrases` source — the same
+ * descriptor the dashboard's bundle review builds (with a `bundle` source).
+ * The phrase is always saved first, so it's referenced by id; all values are
+ * ASCII, so plain base64 is enough.
+ */
+
+/** The eight Gemini voices, mirroring the dashboard's voice list. */
+export const PRACTICE_NOW_VOICES = [
+  "Kore",
+  "Puck",
+  "Charon",
+  "Fenrir",
+  "Aoede",
+  "Leda",
+  "Orus",
+  "Zephyr",
+] as const;
+
+export const DEFAULT_PRACTICE_VOICE = "Kore";
+
+export interface PracticeNowOptions {
+  /** The saved phrase's `_id`. */
+  phraseId: string;
+  /** The chosen coach voice (one of {@link PRACTICE_NOW_VOICES}). */
+  voiceName?: string;
+}
+
+/**
+ * The dashboard-relative path the new tab lands on after the token handoff:
+ * the unified live-session gate, carrying a single-phrase request.
+ */
+export function buildPracticeNowPath({
+  phraseId,
+  voiceName,
+}: PracticeNowOptions): string {
+  const request = {
+    aiCharacter: voiceName || DEFAULT_PRACTICE_VOICE,
+    source: { kind: "phrases", phraseIds: [phraseId] },
+    returnTo: "/board",
+  };
+  const session = btoa(JSON.stringify(request));
+  const params = new URLSearchParams();
+  params.set("session", session);
+  return `/practice/live-session?${params.toString()}`;
+}

--- a/src/console-crane/modules/practice-config/index.vue
+++ b/src/console-crane/modules/practice-config/index.vue
@@ -8,16 +8,17 @@
     the real save UI is shown inline so the user can save and proceed.
   -->
   <div class="flex flex-col min-h-full px-6 py-8 dark:bg-gray-950">
-    <!-- Header -->
-    <div class="mb-5">
-      <div class="flex items-center gap-2">
-        <i class="i-solar-microphone-3-bold text-xl text-purple-500" />
-        <h1 class="text-base font-semibold text-gray-900 dark:text-gray-100">Practice now</h1>
+    <!-- Header: "Practice now" is a small eyebrow; the phrase is the focal point. -->
+    <div class="mb-6">
+      <div class="flex items-center gap-1.5 mb-2">
+        <i class="i-solar-microphone-3-bold text-base text-purple-500" />
+        <span class="text-[11px] uppercase tracking-wider font-semibold text-purple-500 dark:text-purple-300">Practice now</span>
       </div>
-      <p v-if="data.phrase" class="text-sm text-gray-600 dark:text-gray-300 mt-1 break-words"
+      <h1 v-if="data.phrase"
+        class="text-2xl font-bold leading-snug text-gray-900 dark:text-gray-100 break-words"
         :dir="data.direction?.source">
         {{ data.phrase }}
-      </p>
+      </h1>
     </div>
 
     <!-- Resolving saved state -->

--- a/src/console-crane/modules/practice-config/index.vue
+++ b/src/console-crane/modules/practice-config/index.vue
@@ -25,33 +25,10 @@
       <div class="h-6 w-6 animate-spin rounded-full border-2 border-purple-500 border-t-transparent" />
     </div>
 
-    <!-- Not saved yet: prompt to save, then reveal the save widget on demand -->
-    <div v-else-if="!isSaved" class="flex flex-col gap-4">
-      <div class="rounded-xl border border-dashed border-purple-200 dark:border-purple-500/30 bg-purple-50/60 dark:bg-purple-500/[0.06] p-4 text-sm text-purple-800 dark:text-purple-200">
-        To practice this phrase live with the AI coach, you need to save it first.
-      </div>
-
-      <!-- Step 1: invite the user to save -->
-      <Button v-if="!showSaveWidget" label="Let's save it" color="primary" size="lg" class="w-full"
-        @click="showSaveWidget = true">
-        <template #icon><i class="mr-2 i-ep-collection" /></template>
-      </Button>
-
-      <!-- Step 2: the real save widget; on save, the config card appears -->
-      <SaveWordSectionV2
-        v-else
-        :phrase="data.phrase || ''"
-        :translation="data.translation || ''"
-        :context="data.context"
-        :direction="data.direction"
-        :language_info="data.language_info"
-        :linguistic_data="data.linguistic_data"
-        :chunks="data.chunks || []"
-        @saved="onSaved"
-      />
-    </div>
-
-    <!-- Config card -->
+    <!-- Resolved state. The voice picker + duration hint are ALWAYS shown so the
+         page stays consistent; only the footer below changes with the
+         auth / saved / allocation state. The picker stays mounted across saving
+         so the user's voice choice is preserved. -->
     <div v-else class="flex flex-col gap-5">
       <div
         class="rounded-2xl border border-gray-200 dark:border-white/[0.08] bg-gray-50 dark:bg-white/[0.02] p-5 shadow-sm flex flex-col gap-4">
@@ -67,34 +44,76 @@
         <span>Uses some of your monthly credits</span>
       </div>
 
-      <!-- Free-tier session allocation -->
-      <p v-if="isFreemium && freemiumAllocation" class="text-center text-xs"
-        :class="isAtFreeLimit ? 'text-pink-600 dark:text-pink-300' : 'text-gray-500 dark:text-gray-400'">
-        {{ isAtFreeLimit
-          ? `You've used all ${sessionsTotal} free AI sessions this month.`
-          : `${freeSessionsLeft} of ${sessionsTotal} free AI sessions left` }}
-      </p>
+      <!-- Footer — logged out: be explicit that saving follows login before
+           practice can start, so the button doesn't overpromise. -->
+      <template v-if="!isLogin">
+        <p class="text-center text-xs text-gray-500 dark:text-gray-400">
+          Live practice needs a saved phrase. You'll log in and save it first.
+        </p>
+        <Button label="Log in &amp; save first" color="primary" size="lg" class="w-full" @click="handleLoginRequest">
+          <template #icon><i class="mr-2 i-solar-login-3-bold" /></template>
+        </Button>
+      </template>
 
-      <!-- Free + out of allocation: upgrade. Otherwise: start. -->
-      <Button v-if="isFreemium && isAtFreeLimit" label="Upgrade to Premium" color="primary" size="lg" class="w-full"
-        @click="upgrade">
-        <template #icon><i class="mr-2 pi pi-crown" /></template>
-      </Button>
-      <Button v-else label="Start" color="primary" size="lg" class="w-full" :is-loading="starting" @click="start">
-        <template #icon><i class="mr-2 i-solar-play-bold" /></template>
-      </Button>
+      <!-- Footer — logged in but not saved: prompt to save, then the save widget. -->
+      <template v-else-if="!isSaved">
+        <div class="rounded-xl border border-dashed border-purple-200 dark:border-purple-500/30 bg-purple-50/60 dark:bg-purple-500/[0.06] p-4 text-sm text-purple-800 dark:text-purple-200">
+          To practice this phrase live with the AI coach, you need to save it first.
+        </div>
+
+        <!-- Step 1: invite the user to save -->
+        <Button v-if="!showSaveWidget" label="Let's save it" color="primary" size="lg" class="w-full"
+          @click="showSaveWidget = true">
+          <template #icon><i class="mr-2 i-ep-collection" /></template>
+        </Button>
+
+        <!-- Step 2: the real save widget; on save, the footer switches to Start. -->
+        <SaveWordSectionV2
+          v-else
+          :phrase="data.phrase || ''"
+          :translation="data.translation || ''"
+          :context="data.context"
+          :direction="data.direction"
+          :language_info="data.language_info"
+          :linguistic_data="data.linguistic_data"
+          :chunks="data.chunks || []"
+          @saved="onSaved"
+        />
+      </template>
+
+      <!-- Footer — logged in + saved: free-tier allocation note, then Start / Upgrade. -->
+      <template v-else>
+        <p v-if="isFreemium && freemiumAllocation" class="text-center text-xs"
+          :class="isAtFreeLimit ? 'text-pink-600 dark:text-pink-300' : 'text-gray-500 dark:text-gray-400'">
+          {{ isAtFreeLimit
+            ? `You've used all ${sessionsTotal} free AI sessions this month.`
+            : `${freeSessionsLeft} of ${sessionsTotal} free AI sessions left` }}
+        </p>
+
+        <!-- Free + out of allocation: upgrade. Otherwise: start. -->
+        <Button v-if="isFreemium && isAtFreeLimit" label="Upgrade to Premium" color="primary" size="lg" class="w-full"
+          @click="upgrade">
+          <template #icon><i class="mr-2 pi pi-crown" /></template>
+        </Button>
+        <Button v-else label="Start" color="primary" size="lg" class="w-full" :is-loading="starting" @click="start">
+          <template #icon><i class="mr-2 i-solar-play-bold" /></template>
+        </Button>
+      </template>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onMounted, watch } from "vue";
 import { useRoute } from "vue-router";
 import { Button } from "pilotui/elements";
 import { decodeRouteParams } from "../../route-params";
 import { findSavedPhrase } from "../../../common/services/phrase.service";
 import { getSubturtleDashboardUrlWithToken } from "../../../common/static/global";
 import { useProfileStore } from "../../../stores/profile";
+import { isLogin } from "../../../plugins/modular-rest";
+import { sendMessage } from "../../../common/helper/massage";
+import { OpenLoginWindowMessage } from "../../../common/types/messaging";
 import { analytic } from "../../../plugins/mixpanel";
 import { DEFAULT_PRACTICE_VOICE, buildPracticeNowPath } from "./deep-link";
 import SaveWordSectionV2 from "../../components/SaveWordSectionV2.vue";
@@ -134,22 +153,30 @@ const isAtFreeLimit = computed(
 
 const voiceName = ref<string>(DEFAULT_PRACTICE_VOICE);
 
-const checkingSaved = ref(true);
+// Start without the spinner when logged out — there's nothing to look up, so we
+// go straight to the voice preview + login prompt.
+const checkingSaved = ref(isLogin.value);
 const isSaved = ref(false);
 const showSaveWidget = ref(false);
 const phraseId = ref<string | null>(null);
 const starting = ref(false);
 
-onMounted(async () => {
-  analytic.track("practice-config-page_viewed");
-  // Refresh the allocation so "free sessions left" reflects sessions already used.
-  profileStore.fetchSubscription().catch(() => {});
-
+/**
+ * Look up whether this phrase is already saved. Only meaningful when logged in
+ * (the lookup is owner-scoped); logged-out users skip straight to the voice
+ * preview + login prompt.
+ */
+async function checkSaved() {
+  if (!isLogin.value) {
+    checkingSaved.value = false;
+    return;
+  }
   const phrase = (data.value.phrase || "").trim();
   if (!phrase) {
     checkingSaved.value = false;
     return;
   }
+  checkingSaved.value = true;
   try {
     const saved = await findSavedPhrase(phrase);
     if (saved?._id) {
@@ -159,6 +186,23 @@ onMounted(async () => {
   } finally {
     checkingSaved.value = false;
   }
+}
+
+onMounted(() => {
+  analytic.track("practice-config-page_viewed");
+  if (isLogin.value) {
+    // Refresh the allocation so "free sessions left" reflects sessions used.
+    profileStore.fetchSubscription().catch(() => {});
+  }
+  checkSaved();
+});
+
+// When the user logs in from the inline prompt, fetch their allocation and
+// re-check the saved state so the page progresses without a manual reload.
+watch(isLogin, (loggedIn) => {
+  if (!loggedIn) return;
+  profileStore.fetchSubscription().catch(() => {});
+  checkSaved();
 });
 
 /** Inline save completed — reveal the config card with the new phrase id. */
@@ -169,10 +213,17 @@ function onSaved(saved: PhraseType) {
   analytic.track("practice-now_saved-inline");
 }
 
-/** Out of free sessions — open the dashboard subscription page in a new tab. */
+/** Out of free sessions — open the dashboard subscription settings in a new tab. */
 function upgrade() {
   analytic.track("practice-now_upgrade-clicked");
-  window.open(getSubturtleDashboardUrlWithToken(), "_blank");
+  // login_with_token redirects here after the handoff (dashboard hashMode route).
+  window.open(getSubturtleDashboardUrlWithToken("/settings/subscription"), "_blank");
+}
+
+/** Logged out — open the login window; the isLogin watch advances the page. */
+function handleLoginRequest() {
+  analytic.track("practice-now_login-clicked");
+  sendMessage(new OpenLoginWindowMessage());
 }
 
 function start() {

--- a/src/console-crane/modules/practice-config/index.vue
+++ b/src/console-crane/modules/practice-config/index.vue
@@ -1,17 +1,198 @@
 <template>
   <!--
-    Practice now config page (stub).
-    The full config card (voice toggle, voice picker, estimated duration, Start)
-    is delivered in subtask 86exnxnw7. This placeholder makes the "Practice now"
-    button in the save modal navigable without breaking the router.
+    Practice now config page (PRFAQ-001 Phase 1, ClickUp 86exnxnw7).
+    Reached from word-detail's "Practice with AI" button. Picks a coach voice,
+    then opens the dashboard's unified live-session gate to run a voice session.
+    Free users get a monthly allocation of AI sessions (read from profile); once
+    that's used up they're prompted to upgrade. When the phrase isn't saved yet,
+    the real save UI is shown inline so the user can save and proceed.
   -->
-  <div class="flex flex-col items-center justify-center min-h-full px-6 py-10 text-center dark:bg-gray-950">
-    <i class="i-solar-microphone-3-bold text-4xl text-purple-500 mb-4" />
-    <h1 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Practice now</h1>
-    <p class="text-sm text-gray-500 dark:text-gray-400 max-w-sm">
-      The practice session config is coming soon. You can keep saving phrases in the meantime.
-    </p>
+  <div class="flex flex-col min-h-full px-6 py-8 dark:bg-gray-950">
+    <!-- Header -->
+    <div class="mb-5">
+      <div class="flex items-center gap-2">
+        <i class="i-solar-microphone-3-bold text-xl text-purple-500" />
+        <h1 class="text-base font-semibold text-gray-900 dark:text-gray-100">Practice now</h1>
+      </div>
+      <p v-if="data.phrase" class="text-sm text-gray-600 dark:text-gray-300 mt-1 break-words"
+        :dir="data.direction?.source">
+        {{ data.phrase }}
+      </p>
+    </div>
+
+    <!-- Resolving saved state -->
+    <div v-if="checkingSaved" class="flex flex-1 items-center justify-center">
+      <div class="h-6 w-6 animate-spin rounded-full border-2 border-purple-500 border-t-transparent" />
+    </div>
+
+    <!-- Not saved yet: prompt to save, then reveal the save widget on demand -->
+    <div v-else-if="!isSaved" class="flex flex-col gap-4">
+      <div class="rounded-xl border border-dashed border-purple-200 dark:border-purple-500/30 bg-purple-50/60 dark:bg-purple-500/[0.06] p-4 text-sm text-purple-800 dark:text-purple-200">
+        To practice this phrase live with the AI coach, you need to save it first.
+      </div>
+
+      <!-- Step 1: invite the user to save -->
+      <Button v-if="!showSaveWidget" label="Let's save it" color="primary" size="lg" class="w-full"
+        @click="showSaveWidget = true">
+        <template #icon><i class="mr-2 i-ep-collection" /></template>
+      </Button>
+
+      <!-- Step 2: the real save widget; on save, the config card appears -->
+      <SaveWordSectionV2
+        v-else
+        :phrase="data.phrase || ''"
+        :translation="data.translation || ''"
+        :context="data.context"
+        :direction="data.direction"
+        :language_info="data.language_info"
+        :linguistic_data="data.linguistic_data"
+        :chunks="data.chunks || []"
+        @saved="onSaved"
+      />
+    </div>
+
+    <!-- Config card -->
+    <div v-else class="flex flex-col gap-5">
+      <div
+        class="rounded-2xl border border-gray-200 dark:border-white/[0.08] bg-gray-50 dark:bg-white/[0.02] p-5 shadow-sm flex flex-col gap-4">
+        <span class="text-sm font-medium text-gray-800 dark:text-gray-100">Choose a coach voice</span>
+        <VoicePicker v-model="voiceName" />
+      </div>
+
+      <!-- Estimated duration + credit hint -->
+      <div class="flex items-center justify-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+        <i class="i-mdi-clock-outline" />
+        <span>&#8776;3 min</span>
+        <span class="text-gray-300 dark:text-gray-600">&middot;</span>
+        <span>Uses some of your monthly credits</span>
+      </div>
+
+      <!-- Free-tier session allocation -->
+      <p v-if="isFreemium && freemiumAllocation" class="text-center text-xs"
+        :class="isAtFreeLimit ? 'text-pink-600 dark:text-pink-300' : 'text-gray-500 dark:text-gray-400'">
+        {{ isAtFreeLimit
+          ? `You've used all ${sessionsTotal} free AI sessions this month.`
+          : `${freeSessionsLeft} of ${sessionsTotal} free AI sessions left` }}
+      </p>
+
+      <!-- Free + out of allocation: upgrade. Otherwise: start. -->
+      <Button v-if="isFreemium && isAtFreeLimit" label="Upgrade to Premium" color="primary" size="lg" class="w-full"
+        @click="upgrade">
+        <template #icon><i class="mr-2 pi pi-crown" /></template>
+      </Button>
+      <Button v-else label="Start" color="primary" size="lg" class="w-full" :is-loading="starting" @click="start">
+        <template #icon><i class="mr-2 i-solar-play-bold" /></template>
+      </Button>
+    </div>
   </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import { useRoute } from "vue-router";
+import { Button } from "pilotui/elements";
+import { decodeRouteParams } from "../../route-params";
+import { findSavedPhrase } from "../../../common/services/phrase.service";
+import { getSubturtleDashboardUrlWithToken } from "../../../common/static/global";
+import { useProfileStore } from "../../../stores/profile";
+import { analytic } from "../../../plugins/mixpanel";
+import { DEFAULT_PRACTICE_VOICE, buildPracticeNowPath } from "./deep-link";
+import SaveWordSectionV2 from "../../components/SaveWordSectionV2.vue";
+import VoicePicker from "../../components/VoicePicker.vue";
+import type { Chunk } from "../word-detail/types";
+import type { PhraseType } from "../../../common/types/phrase.type";
+
+interface PracticeConfigData {
+  phrase?: string;
+  translation?: string;
+  context?: string;
+  chunks?: Chunk[];
+  direction?: { source: "ltr" | "rtl"; target: "ltr" | "rtl" };
+  language_info?: { source: string; target: string };
+  linguistic_data?: any;
+}
+
+const route = useRoute();
+const profileStore = useProfileStore();
+
+const data = computed<PracticeConfigData>(
+  () => decodeRouteParams<PracticeConfigData>(route.params.data as string) || {}
+);
+
+const isFreemium = computed(() => profileStore.isFreemium);
+
+// Free-tier live-session allocation, read from profile (same fields the
+// dashboard uses). Free users may run sessions until they hit their monthly
+// limit; the server enforces the real cap.
+const freemiumAllocation = computed(() => profileStore.freemiumAllocation);
+const sessionsTotal = computed(() => freemiumAllocation.value?.allowed_lived_sessions ?? 0);
+const sessionsUsed = computed(() => freemiumAllocation.value?.allowed_lived_sessions_used ?? 0);
+const freeSessionsLeft = computed(() => Math.max(0, sessionsTotal.value - sessionsUsed.value));
+const isAtFreeLimit = computed(
+  () => isFreemium.value && !!freemiumAllocation.value && sessionsUsed.value >= sessionsTotal.value
+);
+
+const voiceName = ref<string>(DEFAULT_PRACTICE_VOICE);
+
+const checkingSaved = ref(true);
+const isSaved = ref(false);
+const showSaveWidget = ref(false);
+const phraseId = ref<string | null>(null);
+const starting = ref(false);
+
+onMounted(async () => {
+  analytic.track("practice-config-page_viewed");
+  // Refresh the allocation so "free sessions left" reflects sessions already used.
+  profileStore.fetchSubscription().catch(() => {});
+
+  const phrase = (data.value.phrase || "").trim();
+  if (!phrase) {
+    checkingSaved.value = false;
+    return;
+  }
+  try {
+    const saved = await findSavedPhrase(phrase);
+    if (saved?._id) {
+      isSaved.value = true;
+      phraseId.value = saved._id;
+    }
+  } finally {
+    checkingSaved.value = false;
+  }
+});
+
+/** Inline save completed — reveal the config card with the new phrase id. */
+function onSaved(saved: PhraseType) {
+  if (!saved?._id) return;
+  phraseId.value = saved._id;
+  isSaved.value = true;
+  analytic.track("practice-now_saved-inline");
+}
+
+/** Out of free sessions — open the dashboard subscription page in a new tab. */
+function upgrade() {
+  analytic.track("practice-now_upgrade-clicked");
+  window.open(getSubturtleDashboardUrlWithToken(), "_blank");
+}
+
+function start() {
+  if (!phraseId.value || starting.value) return;
+  starting.value = true;
+
+  analytic.track("practice-now_started", {
+    voiceName: voiceName.value,
+    freemium: isFreemium.value,
+  });
+
+  const path = buildPracticeNowPath({
+    phraseId: phraseId.value,
+    voiceName: voiceName.value,
+  });
+  window.open(getSubturtleDashboardUrlWithToken(path), "_blank");
+
+  // Brief spinner while the tab opens (mirrors HomeView.openDashboard).
+  setTimeout(() => {
+    starting.value = false;
+  }, 500);
+}
+</script>

--- a/src/console-crane/modules/word-detail/index.vue
+++ b/src/console-crane/modules/word-detail/index.vue
@@ -338,8 +338,12 @@ function startPracticeWithAI() {
     "practice-config",
     {
       phrase: cleanText(getProps().word || ""),
+      translation: cleanText(wordData.value?.translation?.phrase || ""),
       context: context.value,
       chunks: wordData.value?.chunks || [],
+      direction: wordData.value?.direction,
+      language_info: wordData.value?.language_info,
+      linguistic_data: wordData.value?.linguistic_data,
     },
     true
   );

--- a/src/console-crane/modules/word-detail/index.vue
+++ b/src/console-crane/modules/word-detail/index.vue
@@ -142,8 +142,10 @@
         </div>
       </section>
 
-      <!-- Phrase actions, kept right under the translation so they're easy to spot -->
-      <div v-if="isLogin && wordData?.translation?.phrase" class="flex items-center gap-2 flex-wrap">
+      <!-- Phrase actions, kept right under the translation so they're easy to spot.
+           Shown to logged-out users too: flashcard preview has no auth guard, and
+           the practice config page handles the login prompt itself. -->
+      <div v-if="wordData?.translation?.phrase" class="flex items-center gap-2 flex-wrap">
         <Button label="Practice with AI" size="sm" text @click="startPracticeWithAI">
           <template #icon>
             <i class="mr-2 i-solar-microphone-3-bold" />

--- a/tests/live-voices.service.test.ts
+++ b/tests/live-voices.service.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Controllable functionProvider mock. The service is a module-level singleton,
+// so each test re-imports a fresh module via vi.resetModules().
+const { runMock } = vi.hoisted(() => ({ runMock: vi.fn() }));
+vi.mock("@modular-rest/client", () => ({
+  functionProvider: { run: (...args: any[]) => runMock(...args) },
+}));
+
+async function loadService() {
+  const mod = await import("../src/common/services/live-voices.service");
+  return mod.LiveVoicesService;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  runMock.mockReset();
+});
+
+describe("LiveVoicesService", () => {
+  it("fetches once and caches the server list", async () => {
+    runMock.mockResolvedValueOnce([{ name: "Kore", label: "Kore" }]);
+    const Service = await loadService();
+
+    const first = await Service.instance.getVoices();
+    const second = await Service.instance.getVoices();
+
+    expect(first).toEqual([{ name: "Kore", label: "Kore" }]);
+    expect(second).toBe(first); // served from cache
+    expect(runMock).toHaveBeenCalledTimes(1);
+    expect(runMock).toHaveBeenCalledWith({
+      name: "get-live-session-voices",
+      args: {},
+    });
+  });
+
+  it("returns an empty list on failure and retries on the next call", async () => {
+    runMock.mockRejectedValueOnce(new Error("network"));
+    const Service = await loadService();
+
+    const first = await Service.instance.getVoices();
+    expect(first).toEqual([]);
+
+    // Failures aren't cached — a later success populates the list.
+    runMock.mockResolvedValueOnce([{ name: "Kore", label: "Kore" }]);
+    const second = await Service.instance.getVoices();
+    expect(second).toEqual([{ name: "Kore", label: "Kore" }]);
+    expect(runMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/practice-config.test.ts
+++ b/tests/practice-config.test.ts
@@ -5,9 +5,9 @@ import { encodeRouteParams } from "../src/console-crane/route-params";
 
 // Drive the route :data payload via a hoisted holder (same approach as
 // flashcard-preview.test.ts), plus holders for the saved-phrase lookup, the
-// freemium flag, and window.open calls.
-const { routeHolder, savedHolder, profileHolder, openHolder } = vi.hoisted(
-  () => ({
+// freemium flag, window.open calls, and the login ref.
+const { routeHolder, savedHolder, profileHolder, openHolder, loginHolder } =
+  vi.hoisted(() => ({
     routeHolder: { data: "" },
     savedHolder: { value: null as { _id: string } | null },
     profileHolder: {
@@ -16,8 +16,9 @@ const { routeHolder, savedHolder, profileHolder, openHolder } = vi.hoisted(
       fetchSubscription: () => Promise.resolve(),
     },
     openHolder: { calls: [] as string[] },
-  })
-);
+    // `ref` is filled in by the modular-rest mock so tests can toggle login.
+    loginHolder: { ref: null as { value: boolean } | null },
+  }));
 
 vi.mock("vue-router", () => ({
   useRoute: () => ({ params: { data: routeHolder.data } }),
@@ -31,6 +32,14 @@ vi.mock("../src/stores/profile", () => ({
 vi.mock("../src/common/static/global", () => ({
   getSubturtleDashboardUrlWithToken: (path?: string) => `OPEN:${path ?? ""}`,
 }));
+// Real Vue ref so the component's template + isLogin watch stay reactive; the
+// heavy modular-rest plugin (chrome APIs, @modular-rest/client) is mocked away.
+vi.mock("../src/plugins/modular-rest", async () => {
+  const { ref } = await import("vue");
+  const isLogin = ref(true);
+  loginHolder.ref = isLogin;
+  return { isLogin };
+});
 
 // Pilotui Button → minimal stub that re-emits click (mirrors word-detail.test.ts).
 vi.mock("pilotui/elements", () => ({
@@ -72,6 +81,8 @@ beforeEach(() => {
   profileHolder.isFreemium = false;
   profileHolder.freemiumAllocation = null;
   openHolder.calls = [];
+  // Default to logged in; the logged-out test flips this before mounting.
+  if (loginHolder.ref) loginHolder.ref.value = true;
   vi.spyOn(window, "open").mockImplementation((url?: string | URL) => {
     openHolder.calls.push(String(url));
     return null;
@@ -82,13 +93,16 @@ describe("PracticeConfig page (voice-only)", () => {
   it("prompts to save first and reveals the save widget on demand", async () => {
     const w = mountWith({ phrase: "had to" });
     await flushPromises();
-    // Step 1: a prompt + "Let's save it" — no save widget, no config card yet.
+    // The voice picker is always shown; the not-saved footer adds the prompt.
+    expect(w.text()).toContain("Choose a coach voice");
+    expect(w.find(".voice-picker-stub").exists()).toBe(true);
+    // Step 1: a prompt + "Let's save it" — no save widget yet.
     expect(w.text()).toContain("Let's save it");
     expect(w.find(".save-stub").exists()).toBe(false);
-    expect(w.text()).not.toContain("Choose a coach voice");
-    // Step 2: clicking it reveals the real save widget.
+    // Step 2: clicking it reveals the real save widget; the picker stays put.
     await w.find("button.pilot-btn").trigger("click");
     expect(w.find(".save-stub").exists()).toBe(true);
+    expect(w.find(".voice-picker-stub").exists()).toBe(true);
     w.unmount();
   });
 
@@ -102,6 +116,22 @@ describe("PracticeConfig page (voice-only)", () => {
     expect(w.find(".voice-picker-stub").exists()).toBe(true);
     expect(w.text()).toContain("Start");
     expect(w.find(".save-stub").exists()).toBe(false);
+    w.unmount();
+  });
+
+  it("shows the voice picker and a login prompt when logged out", async () => {
+    loginHolder.ref!.value = false;
+    const w = mountWith({ phrase: "had to" });
+    await flushPromises();
+    // Voice picker is previewable without auth, plus an inline login CTA that
+    // sets expectations that saving follows login before practice can start.
+    expect(w.text()).toContain("Choose a coach voice");
+    expect(w.find(".voice-picker-stub").exists()).toBe(true);
+    expect(w.text()).toContain("Log in & save first");
+    expect(w.text()).toContain("needs a saved phrase");
+    // Not the save-first flow, and no Start until they log in.
+    expect(w.text()).not.toContain("Let's save it");
+    expect(w.text()).not.toContain("Start");
     w.unmount();
   });
 
@@ -168,8 +198,9 @@ describe("PracticeConfig page (voice-only)", () => {
     expect(w.text()).toContain("used all 3 free AI sessions");
 
     await w.find("button.pilot-btn").trigger("click");
-    // Upgrade opens the dashboard root, not a practice session.
+    // Upgrade opens the dashboard subscription settings, not a practice session.
     expect(openHolder.calls).toHaveLength(1);
+    expect(openHolder.calls[0]).toContain("/settings/subscription");
     expect(openHolder.calls[0]).not.toContain("session=");
     w.unmount();
   });

--- a/tests/practice-config.test.ts
+++ b/tests/practice-config.test.ts
@@ -6,8 +6,14 @@ import { encodeRouteParams } from "../src/console-crane/route-params";
 // Drive the route :data payload via a hoisted holder (same approach as
 // flashcard-preview.test.ts), plus holders for the saved-phrase lookup, the
 // freemium flag, window.open calls, and the login ref.
-const { routeHolder, savedHolder, profileHolder, openHolder, loginHolder } =
-  vi.hoisted(() => ({
+const {
+  routeHolder,
+  savedHolder,
+  profileHolder,
+  openHolder,
+  loginHolder,
+  sendHolder,
+} = vi.hoisted(() => ({
     routeHolder: { data: "" },
     savedHolder: { value: null as { _id: string } | null },
     profileHolder: {
@@ -18,6 +24,8 @@ const { routeHolder, savedHolder, profileHolder, openHolder, loginHolder } =
     openHolder: { calls: [] as string[] },
     // `ref` is filled in by the modular-rest mock so tests can toggle login.
     loginHolder: { ref: null as { value: boolean } | null },
+    // Captures the login-window message dispatched by the logged-out CTA.
+    sendHolder: { calls: [] as any[] },
   }));
 
 vi.mock("vue-router", () => ({
@@ -40,6 +48,13 @@ vi.mock("../src/plugins/modular-rest", async () => {
   loginHolder.ref = isLogin;
   return { isLogin };
 });
+// Spy on the login-window dispatch instead of hitting the chrome runtime shim.
+vi.mock("../src/common/helper/massage", () => ({
+  sendMessage: (arg: any) => {
+    sendHolder.calls.push(arg);
+    return Promise.resolve({});
+  },
+}));
 
 // Pilotui Button → minimal stub that re-emits click (mirrors word-detail.test.ts).
 vi.mock("pilotui/elements", () => ({
@@ -70,6 +85,7 @@ vi.mock("../src/console-crane/components/VoicePicker.vue", () => ({
 }));
 
 import PracticeConfig from "../src/console-crane/modules/practice-config/index.vue";
+import { OpenLoginWindowMessage } from "../src/common/types/messaging";
 
 function mountWith(payload: Record<string, unknown>) {
   routeHolder.data = encodeRouteParams(payload);
@@ -81,6 +97,7 @@ beforeEach(() => {
   profileHolder.isFreemium = false;
   profileHolder.freemiumAllocation = null;
   openHolder.calls = [];
+  sendHolder.calls = [];
   // Default to logged in; the logged-out test flips this before mounting.
   if (loginHolder.ref) loginHolder.ref.value = true;
   vi.spyOn(window, "open").mockImplementation((url?: string | URL) => {
@@ -132,6 +149,36 @@ describe("PracticeConfig page (voice-only)", () => {
     // Not the save-first flow, and no Start until they log in.
     expect(w.text()).not.toContain("Let's save it");
     expect(w.text()).not.toContain("Start");
+    w.unmount();
+  });
+
+  it("dispatches the login-window message from the logged-out CTA", async () => {
+    loginHolder.ref!.value = false;
+    const w = mountWith({ phrase: "had to" });
+    await flushPromises();
+
+    // The only button in the logged-out footer is the login CTA.
+    await w.find("button.pilot-btn").trigger("click");
+    expect(sendHolder.calls).toHaveLength(1);
+    expect(sendHolder.calls[0]).toBeInstanceOf(OpenLoginWindowMessage);
+    w.unmount();
+  });
+
+  it("advances past the login prompt once the user logs in", async () => {
+    loginHolder.ref!.value = false;
+    const w = mountWith({ phrase: "had to" });
+    await flushPromises();
+    expect(w.text()).toContain("Log in & save first");
+
+    // Simulate a completed login: the isLogin watch re-checks the saved state.
+    // Still unsaved here, so the page lands on the save-first flow.
+    loginHolder.ref!.value = true;
+    await flushPromises();
+
+    expect(w.text()).not.toContain("Log in & save first");
+    expect(w.text()).toContain("Let's save it");
+    // The voice picker persists across the transition (never unmounted).
+    expect(w.find(".voice-picker-stub").exists()).toBe(true);
     w.unmount();
   });
 

--- a/tests/practice-config.test.ts
+++ b/tests/practice-config.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { defineComponent } from "vue";
+import { encodeRouteParams } from "../src/console-crane/route-params";
+
+// Drive the route :data payload via a hoisted holder (same approach as
+// flashcard-preview.test.ts), plus holders for the saved-phrase lookup, the
+// freemium flag, and window.open calls.
+const { routeHolder, savedHolder, profileHolder, openHolder } = vi.hoisted(
+  () => ({
+    routeHolder: { data: "" },
+    savedHolder: { value: null as { _id: string } | null },
+    profileHolder: {
+      isFreemium: false,
+      freemiumAllocation: null as any,
+      fetchSubscription: () => Promise.resolve(),
+    },
+    openHolder: { calls: [] as string[] },
+  })
+);
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ params: { data: routeHolder.data } }),
+}));
+vi.mock("../src/common/services/phrase.service", () => ({
+  findSavedPhrase: vi.fn(async () => savedHolder.value),
+}));
+vi.mock("../src/stores/profile", () => ({
+  useProfileStore: () => profileHolder,
+}));
+vi.mock("../src/common/static/global", () => ({
+  getSubturtleDashboardUrlWithToken: (path?: string) => `OPEN:${path ?? ""}`,
+}));
+
+// Pilotui Button → minimal stub that re-emits click (mirrors word-detail.test.ts).
+vi.mock("pilotui/elements", () => ({
+  Button: defineComponent({
+    name: "PilotButton",
+    props: { label: { type: String, default: "" } },
+    emits: ["click"],
+    template:
+      '<button class="pilot-btn" @click="$emit(\'click\')">{{ label }}<slot name="icon" /></button>',
+  }),
+}));
+
+// Heavy children → light stubs. The save stub re-emits `saved` with a phrase doc.
+vi.mock("../src/console-crane/components/SaveWordSectionV2.vue", () => ({
+  default: defineComponent({
+    name: "SaveWordSectionV2Stub",
+    emits: ["saved"],
+    template:
+      "<button class=\"save-stub\" @click=\"$emit('saved', { _id: 'NEWID' })\">save</button>",
+  }),
+}));
+vi.mock("../src/console-crane/components/VoicePicker.vue", () => ({
+  default: defineComponent({
+    name: "VoicePickerStub",
+    props: { modelValue: { type: String, default: "" } },
+    template: '<div class="voice-picker-stub" />',
+  }),
+}));
+
+import PracticeConfig from "../src/console-crane/modules/practice-config/index.vue";
+
+function mountWith(payload: Record<string, unknown>) {
+  routeHolder.data = encodeRouteParams(payload);
+  return mount(PracticeConfig);
+}
+
+beforeEach(() => {
+  savedHolder.value = null;
+  profileHolder.isFreemium = false;
+  profileHolder.freemiumAllocation = null;
+  openHolder.calls = [];
+  vi.spyOn(window, "open").mockImplementation((url?: string | URL) => {
+    openHolder.calls.push(String(url));
+    return null;
+  });
+});
+
+describe("PracticeConfig page (voice-only)", () => {
+  it("prompts to save first and reveals the save widget on demand", async () => {
+    const w = mountWith({ phrase: "had to" });
+    await flushPromises();
+    // Step 1: a prompt + "Let's save it" — no save widget, no config card yet.
+    expect(w.text()).toContain("Let's save it");
+    expect(w.find(".save-stub").exists()).toBe(false);
+    expect(w.text()).not.toContain("Choose a coach voice");
+    // Step 2: clicking it reveals the real save widget.
+    await w.find("button.pilot-btn").trigger("click");
+    expect(w.find(".save-stub").exists()).toBe(true);
+    w.unmount();
+  });
+
+  it("reveals the voice config card after an inline save", async () => {
+    const w = mountWith({ phrase: "had to" });
+    await flushPromises();
+    await w.find("button.pilot-btn").trigger("click"); // Let's save it
+    await w.find(".save-stub").trigger("click"); // save → emits saved
+    await flushPromises();
+    expect(w.text()).toContain("Choose a coach voice");
+    expect(w.find(".voice-picker-stub").exists()).toBe(true);
+    expect(w.text()).toContain("Start");
+    expect(w.find(".save-stub").exists()).toBe(false);
+    w.unmount();
+  });
+
+  it("shows the voice config card immediately when the phrase is already saved", async () => {
+    savedHolder.value = { _id: "PID123" };
+    const w = mountWith({ phrase: "had to" });
+    await flushPromises();
+    expect(w.text()).toContain("Choose a coach voice");
+    expect(w.find(".save-stub").exists()).toBe(false);
+    w.unmount();
+  });
+
+  it("Start (premium) opens a dashboard tab for the saved phrase with the chosen voice", async () => {
+    savedHolder.value = { _id: "PID123" };
+    const w = mountWith({ phrase: "had to" });
+    await flushPromises();
+
+    await w.find("button.pilot-btn").trigger("click");
+
+    expect(openHolder.calls).toHaveLength(1);
+    // The link carries a base64 LiveSessionRequest with a single-phrase source.
+    const session = new URLSearchParams(
+      openHolder.calls[0].split("?")[1]
+    ).get("session") as string;
+    const req = JSON.parse(atob(session));
+    expect(req.source).toEqual({ kind: "phrases", phraseIds: ["PID123"] });
+    expect(req.aiCharacter).toBe("Kore");
+    w.unmount();
+  });
+
+  it("free users with remaining allocation can start (shows sessions left)", async () => {
+    savedHolder.value = { _id: "PID123" };
+    profileHolder.isFreemium = true;
+    profileHolder.freemiumAllocation = {
+      allowed_lived_sessions: 3,
+      allowed_lived_sessions_used: 1,
+    };
+    const w = mountWith({ phrase: "had to" });
+    await flushPromises();
+
+    expect(w.text()).toContain("2 of 3 free AI sessions left");
+    expect(w.text()).not.toContain("Upgrade");
+
+    await w.find("button.pilot-btn").trigger("click");
+    expect(openHolder.calls).toHaveLength(1);
+    const session = new URLSearchParams(
+      openHolder.calls[0].split("?")[1]
+    ).get("session") as string;
+    expect(JSON.parse(atob(session)).source.phraseIds).toEqual(["PID123"]);
+    w.unmount();
+  });
+
+  it("free users at their session limit see Upgrade (no session launch)", async () => {
+    savedHolder.value = { _id: "PID123" };
+    profileHolder.isFreemium = true;
+    profileHolder.freemiumAllocation = {
+      allowed_lived_sessions: 3,
+      allowed_lived_sessions_used: 3,
+    };
+    const w = mountWith({ phrase: "had to" });
+    await flushPromises();
+
+    expect(w.text()).toContain("Upgrade to Premium");
+    expect(w.text()).toContain("used all 3 free AI sessions");
+
+    await w.find("button.pilot-btn").trigger("click");
+    // Upgrade opens the dashboard root, not a practice session.
+    expect(openHolder.calls).toHaveLength(1);
+    expect(openHolder.calls[0]).not.toContain("session=");
+    w.unmount();
+  });
+
+  it("premium users just see Start (no allocation note, no upgrade)", async () => {
+    savedHolder.value = { _id: "PID123" };
+    profileHolder.isFreemium = false;
+    const w = mountWith({ phrase: "had to" });
+    await flushPromises();
+    expect(w.text()).toContain("Start");
+    expect(w.text()).not.toContain("Premium");
+    expect(w.text()).not.toContain("free AI sessions");
+    w.unmount();
+  });
+});

--- a/tests/practice-now-deep-link.test.ts
+++ b/tests/practice-now-deep-link.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  buildPracticeNowPath,
+  PRACTICE_NOW_VOICES,
+  DEFAULT_PRACTICE_VOICE,
+} from "../src/console-crane/modules/practice-config/deep-link";
+
+function decodeSession(path: string) {
+  const params = new URLSearchParams(path.split("?")[1]);
+  return JSON.parse(atob(params.get("session") as string));
+}
+
+// Practice now hands a single-phrase voice session to the unified live-session
+// gate as a base64 LiveSessionRequest (phrases source).
+describe("buildPracticeNowPath", () => {
+  it("targets the unified /practice/live-session gate", () => {
+    const path = buildPracticeNowPath({ phraseId: "abc123", voiceName: "Puck" });
+    expect(path.startsWith("/practice/live-session?session=")).toBe(true);
+  });
+
+  it("encodes a single-phrase source with the chosen voice", () => {
+    const req = decodeSession(
+      buildPracticeNowPath({ phraseId: "abc123", voiceName: "Puck" })
+    );
+    expect(req.aiCharacter).toBe("Puck");
+    expect(req.source).toEqual({ kind: "phrases", phraseIds: ["abc123"] });
+    expect(req.returnTo).toBe("/board");
+  });
+
+  it("defaults the voice to Kore when none is chosen", () => {
+    const req = decodeSession(buildPracticeNowPath({ phraseId: "x" }));
+    expect(req.aiCharacter).toBe("Kore");
+  });
+
+  it("ships the eight Gemini voices with Kore as default", () => {
+    expect(PRACTICE_NOW_VOICES).toHaveLength(8);
+    expect(PRACTICE_NOW_VOICES).toContain("Kore");
+    expect(DEFAULT_PRACTICE_VOICE).toBe("Kore");
+  });
+});
+
+describe("getSubturtleDashboardUrlWithToken redirect handoff", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.SUBTURTLE_DASHBOARD_URL = "https://dash.example";
+  });
+
+  it("appends an encoded redirect when a path is given", async () => {
+    vi.doMock("@modular-rest/client", () => ({
+      authentication: { getToken: "TEST_TOKEN" },
+    }));
+    const { getSubturtleDashboardUrlWithToken } = await import(
+      "../src/common/static/global"
+    );
+    const path = "/practice/live-session?session=eyJhYmMiOjF9";
+    const url = getSubturtleDashboardUrlWithToken(path);
+
+    expect(url).toContain("token=TEST_TOKEN");
+    expect(url.endsWith("&redirect=" + encodeURIComponent(path))).toBe(true);
+  });
+
+  it("omits redirect when no path is given", async () => {
+    vi.doMock("@modular-rest/client", () => ({
+      authentication: { getToken: "TEST_TOKEN" },
+    }));
+    const { getSubturtleDashboardUrlWithToken } = await import(
+      "../src/common/static/global"
+    );
+    expect(getSubturtleDashboardUrlWithToken()).not.toContain("redirect=");
+  });
+});

--- a/tests/word-detail.test.ts
+++ b/tests/word-detail.test.ts
@@ -132,12 +132,16 @@ describe("WordDetail page", () => {
     wrapper.unmount();
   });
 
-  it("hides the action buttons when logged out", async () => {
+  it("still shows the action buttons when logged out", async () => {
+    // Flashcard preview has no auth guard, and practice-config shows its own
+    // login prompt — so both buttons are offered to logged-out users too.
     (isLogin as unknown as { value: boolean }).value = false;
     const { wrapper } = mountWordDetail({ word: "Kinsta Plan" });
     await flushPromises();
 
-    expect(buttonLabels(wrapper).join("|")).not.toContain("Practice with AI");
+    const labels = buttonLabels(wrapper).join("|");
+    expect(labels).toContain("Practice with AI");
+    expect(labels).toContain("Preview flashcard");
     wrapper.unmount();
   });
 


### PR DESCRIPTION
🏷️ PR Title:  
Enhance Practice Now Feature with Voice Session Config, Improved Login Flows, and Dashboard Deep-Linking

## 📋 Summary  
This PR introduces several improvements to the Practice Now feature, including emphasizing practiced phrases during sessions, enabling access to configuration for logged-out users, and refining call-to-action clarity. Additionally, it adds voice session configuration capabilities and supports deep-linking directly to the dashboard for enhanced user navigation.

## 🔗 Related Tasks  
[#8ff3408](https://app.clickup.com/t/8ff3408) - Emphasize practiced phrase + cover login flows  
[#2f09e05](https://app.clickup.com/t/2f09e05) - Open config to logged-out users + clearer CTAs  
[#db1a3fc](https://app.clickup.com/t/db1a3fc) - Voice session config + dashboard deep-link

## 📝 Additional Details  
These changes collectively improve user experience by making practice sessions more interactive and accessible, streamlining user onboarding and login, and enhancing navigation through deep links to key parts of the application.

## 📜 Commit List  
[8ff3408](commit-url) feat(practice-now): emphasize practiced phrase + cover login flows  
[2f09e05](commit-url) feat(practice-now): open config to logged-out users + clearer CTAs  
[db1a3fc](commit-url) feat(practice-now): voice session config + dashboard deep-link