### PR TITLE
fix(popup): render Practice/Preview console pages in the popup router

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,8 @@ Also emits `loading: boolean` mirroring its internal pending state — bind it o
 
 If you ever need this from a content-script bundle that runs alongside ConsoleCrane, use the [bridge](#consolecrane-bridge) instead — don't double-mount the same component on the same page.
 
+**The popup hosts the console pages in its own router — no modal.** `WordDetailModule`'s "Practice with AI" / "Preview flashcard" buttons open the `practice-config` / `flashcard-preview` console pages. On the popup page there's no `console-crane.js` content script and so no modal to render into. Instead the popup registers those console modules as routes in [its own router](src/popup/router.ts) (each wrapped in a back-header [ConsolePageScaffold](src/popup/components/ConsolePageScaffold.vue) under [src/popup/views/](src/popup/views/)), and [src/popup/App.vue](src/popup/App.vue) `provide()`s an `openConsolePage(page, params)` navigator that `router.push`es that route (params Unicode-safely encoded via `encodeRouteParams`). `WordDetailModule` `inject`s it, so the actions render as full popup pages with a working Back. In the console-crane content script there's no provider, so the same module falls back to the store-driven modal (unchanged). Home is `<keep-alive>`d (`include="HomeView"`) so Back returns to the existing translation rather than a blank input. The console modules (`practice-config`, `flashcard-preview`) are router-agnostic — they read only `route.params.data` — so they work in either router unchanged. Regression-tested in [tests/e2e/popup-console-crane.spec.ts](tests/e2e/popup-console-crane.spec.ts).
+
 ### Settings store
 
 [src/common/store/settings.ts](src/common/store/settings.ts) — Pinia store, syncs through background via `SYNC_SETTINGS`. Holds:
@@ -325,6 +327,7 @@ tests/
     translate-flow.spec.ts          # full Persian translate-and-save with page.route stubs
     password-login.spec.ts          # popup password form end-to-end with stubbed /user/login
     visual-scale.spec.ts            # rem→px rewrite regression net
+    popup-console-crane.spec.ts     # popup.html: Practice/Preview navigate to console pages in the popup router (no modal)
 ```
 
 ### Test totals
@@ -461,6 +464,7 @@ Automated:
 - Selection → Subturtle icon → translated card → Save → ConsoleCrane opens with WordDetail rendering Persian content. → [tests/e2e/translate-flow.spec.ts](tests/e2e/translate-flow.spec.ts).
 - Toggling Nibble OFF for a host **while ConsoleCrane is open** does NOT close the modal or release the body scroll lock. → [tests/e2e/console-crane-lifecycle.spec.ts](tests/e2e/console-crane-lifecycle.spec.ts).
 - Popup translate input: auto-focus on open, spinner while pending, re-submit different word resets, no double-fetch on enter mash. → [tests/translate-card.test.ts](tests/translate-card.test.ts).
+- On `popup.html`, translating a phrase then clicking **Practice with AI** / **Preview flashcard** navigates to the matching console page in the popup's own router (no modal); **Back** returns to the kept-alive Home with the translation intact. → [tests/e2e/popup-console-crane.spec.ts](tests/e2e/popup-console-crane.spec.ts).
 - Per-host Nibble toggle persists and normalizes (`www.` strip, case fold, dedup). → [tests/settings-host.test.ts](tests/settings-host.test.ts).
 - ConsoleCrane on Persian / CJK / emoji inputs throws no `InvalidCharacterError` from `btoa` — covered at the encode level, the bridge level, and the full select-and-save flow. → [tests/route-params.test.ts](tests/route-params.test.ts), [tests/e2e/nibble-flow.spec.ts](tests/e2e/nibble-flow.spec.ts), [tests/e2e/translate-flow.spec.ts](tests/e2e/translate-flow.spec.ts).
 - Visual scale is consistent on default-html-fontsize and 24px-html-fontsize hosts (postcss `rem→px` rewrite regression net). → [tests/e2e/visual-scale.spec.ts](tests/e2e/visual-scale.spec.ts).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,10 @@ Implications:
 - **Asset URLs need `web_accessible_resources`.** `chrome.runtime.getURL("/assets/foo.png")` returns `chrome-extension://invalid/` for paths not declared accessible. The manifest already exposes `assets/*` to all URLs.
 - Webpack entry points live in [webpack.config.js](webpack.config.js) — add a new entry there for any new content script.
 
+## Code comments
+
+Multi-line comments and docstrings are fine — encouraged, even, where the *why* is non-obvious (ESM init-order traps, cross-bundle behaviour, browser/extension quirks). Match the surrounding style (`navigation.ts`, `modular-rest.ts`, the `word-detail` JSDoc). There is **no** "one short line max" rule; don't collapse an explanatory block to a single line just to be terse.
+
 ## Shared APIs
 
 ### ConsoleCrane bridge

--- a/src/console-crane/modules/word-detail/index.vue
+++ b/src/console-crane/modules/word-detail/index.vue
@@ -333,38 +333,45 @@ const context = computed(() => {
   return wordData.value?.context || getProps().context || "";
 });
 
+/**
+ * How phrase actions open a console page. The popup provides a router-based
+ * navigator (`openConsolePage`) that renders practice/flashcard as full popup
+ * pages. In the console-crane content script there is no provider, so we fall
+ * back to the store-driven modal. Keeps this shared module agnostic to its host.
+ */
+const openConsolePage = inject<
+  ((page: string, params: Record<string, any>) => void) | null
+>("openConsolePage", null);
+
+function openConsole(page: string, params: Record<string, any>) {
+  if (openConsolePage) openConsolePage(page, params);
+  else useConsoleCraneStore().toggleConsoleCrane(page, params, true);
+}
+
 /** Open the AI practice config page for this phrase. */
 function startPracticeWithAI() {
   analytic.track("practice-now_opened");
-  useConsoleCraneStore().toggleConsoleCrane(
-    "practice-config",
-    {
-      phrase: cleanText(getProps().word || ""),
-      translation: cleanText(wordData.value?.translation?.phrase || ""),
-      context: context.value,
-      chunks: wordData.value?.chunks || [],
-      direction: wordData.value?.direction,
-      language_info: wordData.value?.language_info,
-      linguistic_data: wordData.value?.linguistic_data,
-    },
-    true
-  );
+  openConsole("practice-config", {
+    phrase: cleanText(getProps().word || ""),
+    translation: cleanText(wordData.value?.translation?.phrase || ""),
+    context: context.value,
+    chunks: wordData.value?.chunks || [],
+    direction: wordData.value?.direction,
+    language_info: wordData.value?.language_info,
+    linguistic_data: wordData.value?.linguistic_data,
+  });
 }
 
 /** Open the flashcard cloze preview page for this phrase. */
 function openFlashcardPreview() {
   analytic.track("flashcard-preview_opened");
-  useConsoleCraneStore().toggleConsoleCrane(
-    "flashcard-preview",
-    {
-      phrase: cleanText(getProps().word || ""),
-      translation: cleanText(wordData.value?.translation?.phrase || ""),
-      context: context.value,
-      chunks: wordData.value?.chunks || [],
-      direction: wordData.value?.direction,
-    },
-    true
-  );
+  openConsole("flashcard-preview", {
+    phrase: cleanText(getProps().word || ""),
+    translation: cleanText(wordData.value?.translation?.phrase || ""),
+    context: context.value,
+    chunks: wordData.value?.chunks || [],
+    direction: wordData.value?.direction,
+  });
 }
 
 /**

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -1,18 +1,35 @@
 <template>
   <div class="bg-white dark:bg-gray-950">
     <PopupLoader v-if="!ready" />
-    <router-view v-else />
+    <router-view v-else v-slot="{ Component }">
+      <!-- Keep Home alive so returning from a console page (Back) restores the
+           existing translation + action buttons instead of a blank input. -->
+      <keep-alive include="HomeView">
+        <component :is="Component" />
+      </keep-alive>
+    </router-view>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { ref } from "vue";
+import { ref, provide } from "vue";
 import { RouterView, useRouter } from "vue-router";
 import PopupLoader from "./components/PopupLoader.vue";
+import { encodeRouteParams } from "../console-crane/route-params";
 
 const router = useRouter();
 const ready = ref(false);
 router.isReady().then(() => {
   ready.value = true;
+});
+
+// The console pages (practice-config, flashcard-preview) live in THIS popup
+// router and render as full popup pages — there is no modal on the popup page.
+// WordDetailModule (reused from console-crane) injects this navigator and pushes
+// the popup router. In the console-crane content script there is no provider, so
+// the same module falls back to its store-driven modal — see
+// src/console-crane/modules/word-detail/index.vue.
+provide("openConsolePage", (page: string, params: Record<string, any>) => {
+  router.push({ name: page, params: { data: encodeRouteParams(params) } });
 });
 </script>

--- a/src/popup/components/ConsolePageScaffold.vue
+++ b/src/popup/components/ConsolePageScaffold.vue
@@ -1,0 +1,34 @@
+<template>
+  <!-- Frame for a console page rendered inside the popup router: a sticky back
+       header over the page body. The popup is a real page, so Back is plain
+       router navigation (returns to the kept-alive Home with its translation). -->
+  <div class="min-h-[600px] w-full bg-white dark:bg-gray-950 overflow-y-auto">
+    <div
+      class="sticky top-0 z-10 flex items-center gap-2 px-4 py-3 border-b border-gray-200 dark:border-white/10 bg-white/95 dark:bg-gray-950/95 backdrop-blur"
+    >
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
+        @click="goBack"
+      >
+        <i class="i-mdi-arrow-left text-lg" />
+        Back
+      </button>
+    </div>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRouter } from "vue-router";
+
+const router = useRouter();
+
+function goBack() {
+  // Prefer real history back so we land on the kept-alive Home; fall back to a
+  // Home push if this page was somehow entered without a prior entry.
+  const hasBack = !!(window.history.state && window.history.state.back != null);
+  if (hasBack) router.back();
+  else router.push({ name: "home" });
+}
+</script>

--- a/src/popup/router.ts
+++ b/src/popup/router.ts
@@ -8,6 +8,8 @@ import HomeView from "./views/HomeView.vue";
 import LoginView from "./views/LoginView.vue";
 import IntroView from "./views/IntroView.vue";
 import HelpView from "./views/HelpView.vue";
+import PracticeConfigView from "./views/PracticeConfigView.vue";
+import FlashcardPreviewView from "./views/FlashcardPreviewView.vue";
 
 const routes: RouteRecordRaw[] = [
   {
@@ -29,6 +31,19 @@ const routes: RouteRecordRaw[] = [
     path: "/help",
     name: "help",
     component: HelpView,
+  },
+  // Console pages, hosted in the popup router so they render as full popup pages
+  // (not a modal). Reached from WordDetailModule's phrase actions via the
+  // openConsolePage navigator provided in App.vue. `:data` is the encoded params.
+  {
+    path: "/practice-config/:data",
+    name: "practice-config",
+    component: PracticeConfigView,
+  },
+  {
+    path: "/flashcard-preview/:data",
+    name: "flashcard-preview",
+    component: FlashcardPreviewView,
   },
 ];
 

--- a/src/popup/views/FlashcardPreviewView.vue
+++ b/src/popup/views/FlashcardPreviewView.vue
@@ -1,0 +1,12 @@
+<template>
+  <ConsolePageScaffold>
+    <FlashcardPreviewPage />
+  </ConsolePageScaffold>
+</template>
+
+<script setup lang="ts">
+// Popup route wrapper around the shared flashcard-preview console module. The
+// module reads its data from this popup route's `:data` param — router-agnostic.
+import ConsolePageScaffold from "../components/ConsolePageScaffold.vue";
+import FlashcardPreviewPage from "../../console-crane/modules/flashcard-preview/index.vue";
+</script>

--- a/src/popup/views/HomeView.vue
+++ b/src/popup/views/HomeView.vue
@@ -297,6 +297,10 @@ import { getSubturtleDashboardUrlWithToken } from "../../common/static/global";
 import { useSettingsStore } from "../../common/store/settings";
 import TranslateCard from "../components/TranslateCard.vue";
 
+// Named so App.vue's <keep-alive include="HomeView"> can cache this view —
+// returning from a console page (Back) then restores the existing translation.
+defineOptions({ name: "HomeView" });
+
 const router = useRouter();
 const isLoading = ref(false);
 const showLogoutConfirm = ref(false);

--- a/src/popup/views/PracticeConfigView.vue
+++ b/src/popup/views/PracticeConfigView.vue
@@ -1,0 +1,13 @@
+<template>
+  <ConsolePageScaffold>
+    <PracticeConfigPage />
+  </ConsolePageScaffold>
+</template>
+
+<script setup lang="ts">
+// Popup route wrapper around the shared practice-config console module. The
+// module reads { phrase, ... } from this popup route's `:data` param (encoded by
+// App.vue's openConsolePage navigator) — it's router-agnostic.
+import ConsolePageScaffold from "../components/ConsolePageScaffold.vue";
+import PracticeConfigPage from "../../console-crane/modules/practice-config/index.vue";
+</script>

--- a/tests/e2e/popup-console-crane.spec.ts
+++ b/tests/e2e/popup-console-crane.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from "./extension-fixture";
+import type { Route, Page } from "@playwright/test";
+
+// Regression test for ClickUp 86exu5xd7 — "Bring the ConsoleCrane into popup app".
+//
+// The popup reuses WordDetailModule, whose "Practice with AI" / "Preview
+// flashcard" buttons open the practice-config / flashcard-preview console pages.
+// On the popup page (no console-crane.js content script) these are hosted in the
+// popup's OWN router and render as full popup pages — no modal. This drives the
+// real popup.html end-to-end:
+//
+//   open popup.html → translate stub → WordDetail renders + action buttons →
+//   click → popup router navigates to the console page (no modal) → Back →
+//   Home is restored (kept-alive) with the translation still shown.
+
+async function stubTranslate(page: Page) {
+  await page.route("**/function/run", async (route: Route) => {
+    const body = route.request().postDataJSON();
+    if (body?.name === "translateWithContext") {
+      const phrase: string = body.args?.phrase ?? "";
+      const context: string = body.args?.context ?? "";
+
+      if (body.args?.translationType === "simple") {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ data: `[stub] ${phrase}` }),
+        });
+      }
+
+      // detailed — a truthy translation.phrase is what makes the action buttons show.
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: {
+            translation: { phrase: `[translated] ${phrase}`, context: "" },
+            direction: { source: "ltr", target: "ltr" },
+            language_info: { source: "English", target: "Spanish" },
+            linguistic_data: {
+              isValid: true,
+              type: "noun",
+              definition: "a container with a flat base and sides",
+              phonetic: { transliteration: "bɒks" },
+              formality_level: "neutral",
+            },
+            chunks: [],
+            context,
+          },
+        }),
+      });
+    }
+    return route.fallback();
+  });
+
+  // Auth + saved-phrase lookups offline so the anonymous-login chain doesn't
+  // reach the network or stall the flow.
+  await page.route("**/user/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: {} }),
+    })
+  );
+  await page.route("**/data-provider/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: null }),
+    })
+  );
+}
+
+/**
+ * Open the popup page and translate a phrase. Asserts there is NO ConsoleCrane
+ * modal app on the popup page (the old approach), then returns once WordDetail
+ * has rendered its action buttons.
+ */
+async function openPopupAndTranslate(page: Page, extensionId: string) {
+  await stubTranslate(page);
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+
+  // No modal ConsoleCrane app is mounted on the popup page anymore.
+  await expect(page.locator("#subturtle-console-crane-root")).toHaveCount(0);
+
+  const input = page.getByPlaceholder("Type or paste any text");
+  await expect(input).toBeVisible({ timeout: 15_000 });
+  await input.fill("box");
+  await input.press("Enter");
+
+  await expect(
+    page.locator('#subturtle-popup button:has-text("Practice with AI")')
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe("Popup: ConsoleCrane phrase actions (router pages, no modal)", () => {
+  test('"Practice with AI" navigates to the practice page; Back restores Home', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await context.newPage();
+    await openPopupAndTranslate(page, extensionId);
+
+    await page
+      .locator('#subturtle-popup button:has-text("Practice with AI")')
+      .click();
+
+    // Popup router navigated to the console page — full popup page, no modal.
+    await expect(page.locator("#subturtle-popup")).toContainText(
+      "Choose a coach voice",
+      { timeout: 15_000 }
+    );
+    expect(page.url()).toContain("#/practice-config/");
+    await expect(page.locator("#subturtle-console-crane-root")).toHaveCount(0);
+
+    // Back returns to the kept-alive Home with the translation still rendered.
+    await page.locator('#subturtle-popup button:has-text("Back")').click();
+    await expect(page.getByPlaceholder("Type or paste any text")).toBeVisible();
+    await expect(
+      page.locator('#subturtle-popup button:has-text("Practice with AI")')
+    ).toBeVisible();
+
+    await page.close();
+  });
+
+  test('"Preview flashcard" navigates to the flashcard page', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await context.newPage();
+    await openPopupAndTranslate(page, extensionId);
+
+    await page
+      .locator('#subturtle-popup button:has-text("Preview flashcard")')
+      .click();
+
+    await expect(page.locator("#subturtle-popup")).toContainText(
+      "Flashcard preview",
+      { timeout: 15_000 }
+    );
+    expect(page.url()).toContain("#/flashcard-preview/");
+    await expect(page.locator("#subturtle-console-crane-root")).toHaveCount(0);
+
+    await page.close();
+  });
+});


### PR DESCRIPTION
🏷️ PR Title:  
Fix popup router to render Practice/Preview console pages and clarify multi-line comment rules

## 📋 Summary  
This PR addresses two main updates: it fixes the popup router to correctly render Practice and Preview console pages, and updates documentation to clarify that multi-line comments are allowed without any "one short line" restriction.

## 🔗 Related Tasks  
[#950a15d](https://app.clickup.com/t/950a15d) - Clarify multi-line comments are allowed (no "one short line" rule)  
[#ff2935c](https://app.clickup.com/t/ff2935c) - Fix popup router to render Practice/Preview console pages

## 📝 Additional Details  
The documentation update improves developer clarity on comment formatting. The popup router fix enhances UI navigation by ensuring console pages render correctly within the popup context.

## 📜 Commit List  
[950a15d](commit-url) docs: clarify multi-line comments are allowed (no "one short line" rule)  
[ff2935c](commit-url) fix(popup): render Practice/Preview console pages in the popup router