### PR TITLE
feat: update extension name & description for store search #86exwn9v0

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -1,3 +1,10 @@
+# [1.15.0-dev.1](https://github.com/codebridger/subturtle-extension-apps/compare/v1.14.1...v1.15.0-dev.1) (2026-06-09)
+
+
+### Features
+
+* Updated the package title and description ([fc73a6c](https://github.com/codebridger/subturtle-extension-apps/commit/fc73a6c545846055f86cad9b3cabeaf09e1d2f5d))
+
 ## [1.14.1-dev.2](https://github.com/codebridger/subturtle-extension-apps/compare/v1.14.1-dev.1...v1.14.1-dev.2) (2026-06-08)
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,8 @@ A top-level `concurrency:` block keys on `github.ref`, so two pushes to the same
 
 If you squash-merge PRs, GitHub uses the **PR title** as the squash commit message, so PR titles must follow this convention to drive the right bump.
 
+**Always include the ClickUp task ID in the commit message.** Reference it as `#<task-id>` (e.g. `fix(console-crane): align bundle selector height #86exw6kme`), matching existing history (`#86et9bk39`, `CU-86exvrzy8`). It can go in the subject or the body, and it links the commit back to the task in ClickUp. When a change closes a task, put the ID on every commit for that task; for squash-merged PRs put it in the PR title.
+
 ### `prepareCmd` does not build
 
 [release.config.cjs](release.config.cjs) `prepareCmd` only runs `scripts/sync-manifest-version.mjs`. The build/zip happen earlier as explicit workflow steps so they're visible in CI logs and have access to the env file. Don't move build/zip back into `prepareCmd`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subturtle-extension",
-  "version": "1.14.1",
+  "version": "1.15.0-dev.1",
   "private": true,
   "scripts": {
     "dev": "webpack --watch",

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,6 +1,6 @@
 {
-	"name": "Subturtle",
-	"description": "Turn video subtitles into English lessons. Learn new vocabulary in context as you watch on YouTube and Netflix.",
+	"name": "Subturtle: Learn English with Subtitles, Videos & AI Coach",
+	"description": "Learn English from any video or web page: tap a subtitle word for its meaning, save and review words, and speak with an AI coach.",
 	"version": "1.14.1.2",
 	"manifest_version": 3,
 	"icons": {

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Subturtle: Learn English with Subtitles, Videos & AI Coach",
 	"description": "Learn English from any video or web page: tap a subtitle word for its meaning, save and review words, and speak with an AI coach.",
-	"version": "1.14.1.2",
+	"version": "1.15.0.1",
 	"manifest_version": 3,
 	"icons": {
 		"128": "/assets/logo-128.png",
@@ -80,5 +80,5 @@
 			]
 		}
 	],
-	"version_name": "1.14.1-dev.2"
+	"version_name": "1.15.0-dev.1"
 }


### PR DESCRIPTION
## What this PR does
- **New store name & description** in `static/manifest.json`, written for search:
  - Name: `Subturtle: Learn English with Subtitles, Videos & AI Coach`
  - Description: `Learn English from any video or web page: tap a subtitle word for its meaning, save and review words, and speak with an AI coach.`
- **New commit rule** in `CLAUDE.md`: every commit message must include its ClickUp task ID (`#<task-id>`).
- **Version bump** to `1.15.0-dev.1` (package.json + manifest), via release automation.

## Why
The old name ("Subturtle") and description left out the words people actually search for ("learn English", "subtitles", "videos", "AI coach"), so the listing was hard to find. The new copy leads with the brand, then the top keywords, and stays true to the product (no price, no overclaim). It matches the store media kit in `subturtle-doc` (`mediakits/extension-1.14.1.txt`).

## Files
- `static/manifest.json` — name, description, version, version_name
- `package.json` — 1.14.1 → 1.15.0-dev.1
- `CLAUDE.md` — require ClickUp task ID in commits
- `CHANGELOG-DEV.md` — 1.15.0-dev.1 entry (auto)